### PR TITLE
Support package names in the module comments. Fixes #17.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,13 @@ Also, you can indicate a particular version condition, examples::
     import somemodule   # fades.pypi == 3
     import somemodule   # fades.pypi >= 2.1
 
+Sometimes, the project itself doesn't match the name of the module; in
+these cases you can specify the project name (optionally, before the
+version)::
+
+    import bs4   # fades.pypi beautifulsoup4
+    import bs4   # fades.pypi beautifulsoup4 == 4.2
+
 
 How to control the virtualenv creation and usage?
 -------------------------------------------------


### PR DESCRIPTION
Code and tests, not only adding the functionality for "projectname" itself, but also exploding on bad comparisons like "<>".

Note: when we search for a comment, before we find "fades.pypi", we just log in warning, but after that the syntax is rigid, so if the user fails to write that properly and we don't understand it, it's better to raise an Exception.