### PR TITLE
dont install pip every time

### DIFF
--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -84,3 +84,4 @@ class PipManager():
         logger.debug("Installing PIP manually in the virtualenv")
         python_exe = os.path.join(self.env_bin_path, "python")
         helpers.logged_exec([python_exe, self.pip_installer_fname])
+        self.pip_installed = True


### PR DESCRIPTION
This should avoid having to install pip many times in the same run, as evidenced by this log:

```
*** fades ***  2015-07-04 23:50:28,439  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:50:39,776  fades.pipmanager   INFO     Installing dependency: RandomWords==0.1.12
*** fades ***  2015-07-04 23:50:47,016  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:50:50,136  fades.pipmanager   INFO     Installing dependency: amqp==1.4.6
*** fades ***  2015-07-04 23:50:53,845  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:50:56,875  fades.pipmanager   INFO     Installing dependency: anyjson==0.3.3
*** fades ***  2015-07-04 23:51:00,574  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:51:03,738  fades.pipmanager   INFO     Installing dependency: argparse==1.2.1
*** fades ***  2015-07-04 23:51:05,828  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:51:08,973  fades.pipmanager   INFO     Installing dependency: billiard==3.3.0.20
*** fades ***  2015-07-04 23:51:14,782  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:51:17,976  fades.pipmanager   INFO     Installing dependency: celery==3.1.18
*** fades ***  2015-07-04 23:51:25,691  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:51:28,993  fades.pipmanager   INFO     Installing dependency: kombu==3.0.26
*** fades ***  2015-07-04 23:51:31,287  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:51:34,571  fades.pipmanager   INFO     Installing dependency: pytz==2015.4
*** fades ***  2015-07-04 23:51:36,826  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:51:39,909  fades.pipmanager   INFO     Installing dependency: ujson==1.33
*** fades ***  2015-07-04 23:51:42,007  fades.pipmanager   INFO     Need to install a dependency with pip, but no builtin, do it manually
*** fades ***  2015-07-04 23:51:45,069  fades.pipmanager   INFO     Installing dependency: wsgiref==0.1.2

```