### PR TITLE
added an option to execute ipython

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,9 @@ On the other hand if you pass the ``-q`` or ``--quiet`` parameter, *fades*
 will not show anything (unless it has a real problem), so the original
 script stderr is not polluted at all.
 
+If you want to use IPython shell you need to call *fades* with ``-i`` or
+``--ipython`` option. This option will add IPython as a dependency to *fades*
+and it will launch this shell instead of the python one.
 
 Some command line examples
 --------------------------

--- a/fades/main.py
+++ b/fades/main.py
@@ -48,7 +48,7 @@ parameters passed as is to the child program.
 """
 
 help_usage = """
-  fades [-h] [-V] [-v] [-q] [-d DEPENDENCY] [-r REQUIREMENT] [-p PYTHON]
+  fades [-h] [-V] [-v] [-q] [-i] [-d DEPENDENCY] [-r REQUIREMENT] [-p PYTHON]
         [child_program [child_options]]
 """
 

--- a/fades/main.py
+++ b/fades/main.py
@@ -82,8 +82,7 @@ def go(version, argv):
     parser.add_argument('-p', '--python', action='store',
                         help=("Specify the Python interpreter to use.\n"
                               " Default is: %s") % (sys.executable,))
-    parser.add_argument('-i', '--ipython', action='store_true',
-                        help="use IPython shell.")
+    parser.add_argument('-i', '--ipython', action='store_true', help="use IPython shell.")
     parser.add_argument('child_program', nargs='?', default=None)
     parser.add_argument('child_options', nargs=argparse.REMAINDER)
 
@@ -132,9 +131,7 @@ def go(version, argv):
     l.debug("Dependencies from requirements file: %s", reqfile_deps)
     manual_deps = parsing.parse_manual(args.dependency)
     l.debug("Dependencies from parameters: %s", manual_deps)
-    indicated_deps = _merge_deps(
-        ipython_dep, indicated_deps, reqfile_deps, manual_deps
-    )
+    indicated_deps = _merge_deps(ipython_dep, indicated_deps, reqfile_deps, manual_deps)
 
     # get the interpreter version requested for the child_program
     interpreter, is_current = helpers.get_interpreter_version(args.python)

--- a/fades/main.py
+++ b/fades/main.py
@@ -122,6 +122,7 @@ def go(version, argv):
 
     # parse file and get deps
     if args.ipython:
+        l.debug("Adding ipython dependency because --ipython was detected")
         ipython_dep = parsing.parse_manual(['ipython'])
     else:
         ipython_dep = []

--- a/man/fades.1
+++ b/man/fades.1
@@ -4,11 +4,12 @@ fades \- FAst DEpendencies for Scripts.
 
 
 .SH SYNOPSYS
-.B fades 
+.B fades
 [\fB-h\fR][\fB--help\fR]
 [\fB-V\fR][\fB--version\fR]
 [\fB-v\fR][\fB--verbose\fR]
 [\fB-q\fR][\fB--quiet\fR]
+[\fB-i\fR][\fB--ipython\fR]
 [\fB-d\fR][\fB--dependency\fR]
 [\fB-r\fR][\fB--requirement\fR]
 [\fB-p\fR \fIversion\fR][\fB--python\fR=\fIversion\fR]
@@ -19,7 +20,7 @@ fades \- FAst DEpendencies for Scripts.
 
 .SH DESCRIPTION
 
-\fBfades\fR will automagically create a new virtualenv (or reuse a previous created one), installing the necessary dependencies, and execute your script inside that virtualenv, with the only requirement of executing the script with \fBfades\fR and also marking the required dependencies. 
+\fBfades\fR will automagically create a new virtualenv (or reuse a previous created one), installing the necessary dependencies, and execute your script inside that virtualenv, with the only requirement of executing the script with \fBfades\fR and also marking the required dependencies.
 
 The first non-option parameter (if any) would be then the child program to execute, and any other parameters after that are passed as is to that child script.
 
@@ -42,6 +43,10 @@ Send all internal debugging lines to stderr, which may be very useful if any pro
 .TP
 .BR -q ", " --quiet
 Don't show anything (unless it has a real problem), so the original script stderr is not polluted at all.
+
+.TP
+.BR -i ", " --ipython
+Runs IPython shell instead of python ones.
 
 .TP
 .BR -d ", " --dependency


### PR DESCRIPTION
Added an option use ipython instead of python shell. 

The option is -i | --ipython. This option add ipython as a dependency.

Examples:
`$ fades -i -d requests`

`$ echo "import requests; print(requests.__version__)" > foo.py`
`$ fades -i -d requests foo.py -i`

In the last example, first *i* means "use IPython" while second *i* is a parameter to IPython shell indicating that we want to use interactive session.