### PR TITLE
run tests using fades to install the necessary dependencies

### DIFF
--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -15,22 +15,7 @@ Clone the project::
 Install dependencies
 --------------------
 
-Fades depends on several packages for development, here are the
-instructions to install them for each OS.
-
-- Ubuntu/Debian::
-
-    apt-get install python-xdg python3-nose python3-flake8
-
-- And on Archlinux with::
-
-    pacman -S python-xdg python-nose flake8
-
-Also, you need to install a package from PyPI, do the following
-with ``sudo`` if you'll install it at system level, or just as it is
-to install it in a virtualenv::
-
-    pip3 install logassert
+*fades* manages it's own dependencies, so there is nothing extra you need to install.
 
 
 How to run the tests

--- a/README.rst
+++ b/README.rst
@@ -182,7 +182,19 @@ Several instructions to install fades in different systems.
 Dependencies
 ------------
 
-Fades needs the `virtualenv <https://virtualenv.pypa.io/en/latest/>` package to
+Fades depends on ``python-xdg`` package. This package should be installed on
+any GNU/Linux OS wiht a freedesktop.org GUI. However it is an
+**optional** dependency.
+
+You can install it in Ubuntu/Debian with::
+
+    apt-get install python-xdg
+
+And on Archlinux with::
+
+    pacman -S python-xdg
+
+Fades also needs the `virtualenv <https://virtualenv.pypa.io/en/latest/>` package to
 support different Python versions for child execution. (see `--python` argument.)
 
 It also depends on the ``pkg_resources`` package, that comes in with

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,9 @@ On the other hand if you pass the ``-q`` or ``--quiet`` parameter, *fades*
 will not show anything (unless it has a real problem), so the original
 script stderr is not polluted at all.
 
+Sometimes, you want to run a script provided by one of the dependencies
+installed into the virtualenv. *fades* supports this via the ``-x`` (
+or ``--executable`` argument).
 
 Some command line examples
 --------------------------
@@ -165,6 +168,9 @@ Executes the Python interactive interpreter in a virtualenv with ``dependency1``
 
 Executes the Python interactive interpreter in a virtualenv after installing there all dependencies taken from the ``requirements.txt`` file.
 
+``fades -d django -x django-admin.py startproject foo``
+
+Uses the ``django-admin.py`` script to start a new project named ``foo``, without having to have django previously installed.
 
 
 How to install it
@@ -176,19 +182,7 @@ Several instructions to install fades in different systems.
 Dependencies
 ------------
 
-Fades depends on ``python-xdg`` package. This package should be installed on
-any GNU/Linux OS wiht a freedesktop.org GUI. However it is an
-**optional** dependency.
-
-You can install it in Ubuntu/Debian with::
-
-    apt-get install python-xdg
-
-And on Archlinux with::
-
-    pacman -S python-xdg
-
-Fades also needs the `virtualenv <https://virtualenv.pypa.io/en/latest/>` package to
+Fades needs the `virtualenv <https://virtualenv.pypa.io/en/latest/>` package to
 support different Python versions for child execution. (see `--python` argument.)
 
 It also depends on the ``pkg_resources`` package, that comes in with

--- a/fades/main.py
+++ b/fades/main.py
@@ -82,7 +82,7 @@ def go(version, argv):
     parser.add_argument('-p', '--python', action='store',
                         help=("Specify the Python interpreter to use.\n"
                               " Default is: %s") % (sys.executable,))
-    parser.add_argument('-x', '--executable', action='store_true',
+    parser.add_argument('-x', '--exec', action='store_true',
                         help=("Indicate that the child_program should be looked up in the "
                               "virtualenv."))
     parser.add_argument('child_program', nargs='?', default=None)
@@ -122,7 +122,7 @@ def go(version, argv):
         l.warning("Overriding 'quiet' option ('verbose' also requested)")
 
     # parse file and get deps
-    if args.executable:
+    if args['exec']:
         indicated_deps = {}
     else:
         indicated_deps = parsing.parse_srcfile(args.child_program)
@@ -151,7 +151,7 @@ def go(version, argv):
         p = subprocess.Popen([python_exe])
 
     else:
-        if args.executable:
+        if args['exec']:
             cmd = [os.path.join(venv_data['env_bin_path'], args.child_program)]
         else:
             cmd = [python_exe, args.child_program]

--- a/fades/main.py
+++ b/fades/main.py
@@ -82,7 +82,7 @@ def go(version, argv):
     parser.add_argument('-p', '--python', action='store',
                         help=("Specify the Python interpreter to use.\n"
                               " Default is: %s") % (sys.executable,))
-    parser.add_argument('-x', '--exec', action='store_true',
+    parser.add_argument('-x', '--exec', dest='executable', action='store_true',
                         help=("Indicate that the child_program should be looked up in the "
                               "virtualenv."))
     parser.add_argument('child_program', nargs='?', default=None)
@@ -122,7 +122,7 @@ def go(version, argv):
         l.warning("Overriding 'quiet' option ('verbose' also requested)")
 
     # parse file and get deps
-    if args['exec']:
+    if args.executable:
         indicated_deps = {}
     else:
         indicated_deps = parsing.parse_srcfile(args.child_program)
@@ -151,7 +151,7 @@ def go(version, argv):
         p = subprocess.Popen([python_exe])
 
     else:
-        if args['exec']:
+        if args.executable:
             cmd = [os.path.join(venv_data['env_bin_path'], args.child_program)]
         else:
             cmd = [python_exe, args.child_program]

--- a/fades/main.py
+++ b/fades/main.py
@@ -83,7 +83,8 @@ def go(version, argv):
                         help=("Specify the Python interpreter to use.\n"
                               " Default is: %s") % (sys.executable,))
     parser.add_argument('-x', '--executable', action='store_true',
-                        help=("TBD."))
+                        help=("Indicate that the child_program should be looked up in the "
+                              "virtualenv."))
     parser.add_argument('child_program', nargs='?', default=None)
     parser.add_argument('child_options', nargs=argparse.REMAINDER)
 

--- a/fades/main.py
+++ b/fades/main.py
@@ -82,6 +82,8 @@ def go(version, argv):
     parser.add_argument('-p', '--python', action='store',
                         help=("Specify the Python interpreter to use.\n"
                               " Default is: %s") % (sys.executable,))
+    parser.add_argument('-x', '--executable', action='store_true',
+                        help=("TBD."))
     parser.add_argument('child_program', nargs='?', default=None)
     parser.add_argument('child_options', nargs=argparse.REMAINDER)
 
@@ -119,8 +121,11 @@ def go(version, argv):
         l.warning("Overriding 'quiet' option ('verbose' also requested)")
 
     # parse file and get deps
-    indicated_deps = parsing.parse_srcfile(args.child_program)
-    l.debug("Dependencies from source file: %s", indicated_deps)
+    if args.executable:
+        indicated_deps = {}
+    else:
+        indicated_deps = parsing.parse_srcfile(args.child_program)
+        l.debug("Dependencies from source file: %s", indicated_deps)
     reqfile_deps = parsing.parse_reqfile(args.requirement)
     l.debug("Dependencies from requirements file: %s", reqfile_deps)
     manual_deps = parsing.parse_manual(args.dependency)
@@ -145,9 +150,13 @@ def go(version, argv):
         p = subprocess.Popen([python_exe])
 
     else:
-        l.debug("Calling the child Python program %r with options %s",
+        if args.executable:
+            cmd = [os.path.join(venv_data['env_bin_path'], args.child_program)]
+        else:
+            cmd = [python_exe, args.child_program]
+        l.debug("Calling the child program %r with options %s",
                 args.child_program, args.child_options)
-        p = subprocess.Popen([python_exe, args.child_program] + args.child_options)
+        p = subprocess.Popen(cmd + args.child_options)
 
         def _signal_handler(signum, _):
             """Handle signals received by parent process, send them to child."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pep8==1.5.7
 pyflakes==0.8.1
 pyxdg==0.25
 wheel==0.24.0
+rst2html5==1.7.5

--- a/test
+++ b/test
@@ -10,9 +10,10 @@ else
     TARGET="fades tests"
 fi
 
+FADES='./bin/fades -r requirements.txt'
 
-nosetests3 -v -s $TARGET
-flake8 $TARGET --max-line-length=99 --select=E,W,F,C,N
+$FADES -x nosetests -- -v -s $TARGET
+$FADES -x flake8 -- $TARGET --max-line-length=99 --select=E,W,F,C,N
 
 # On Archlinux rst2html is rst2html2
 if hash rst2html > /dev/null 2>&1; then
@@ -22,7 +23,7 @@ if hash rst2html > /dev/null 2>&1; then
     fi
 
 # Check README.rst format.
-OUTPUT=$(python3 setup.py --long-description | $RST2HTML > /dev/null 2>&1)
+OUTPUT=$(python3 setup.py --long-description | $FADES -x $RST2HTML > /dev/null 2>&1)
 if [ -n "$OUTPUT" ]; then
     echo -e "README.rst format is incorrect\n"
     echo -e "Errors: \n$OUTPUT"

--- a/test
+++ b/test
@@ -15,15 +15,8 @@ FADES='./bin/fades -r requirements.txt'
 $FADES -x nosetests -- -v -s $TARGET
 $FADES -x flake8 -- $TARGET --max-line-length=99 --select=E,W,F,C,N
 
-# On Archlinux rst2html is rst2html2
-if hash rst2html > /dev/null 2>&1; then
-        RST2HTML='rst2html'
-    else
-        RST2HTML='rst2html2'
-    fi
-
 # Check README.rst format.
-OUTPUT=$(python3 setup.py --long-description | $FADES -x $RST2HTML > /dev/null 2>&1)
+OUTPUT=$(python3 setup.py --long-description | $FADES -x rst2html > /dev/null 2>&1)
 if [ -n "$OUTPUT" ]; then
     echo -e "README.rst format is incorrect\n"
     echo -e "Errors: \n$OUTPUT"


### PR DESCRIPTION
With these changes it's now possible to simply run the tests using the 'test' script without previously having to install the dependencies system-wide or in a virtualenv.