### PR TITLE
Remove virtualenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,19 @@ If you want to use IPython shell you need to call *fades* with ``-i`` or
 ``--ipython`` option. This option will add IPython as a dependency to *fades*
 and it will launch this shell instead of the python one.
 
+
+How to clean up old virtualenvs?
+--------------------------------
+
+When using *fades* virtual environments are something you should not have to think about.
+*fades* will do the right thing and create a new virtualenv that matches the required
+dependencies. There are cases however when you'll want to do some clean up to remove
+unnecessary virtual environments from disk.
+
+By running *fades* with the ``--rm`` argument, *fades* will remove the virtualenv
+matching the requirements after running the script or command specified.
+
+
 Some command line examples
 --------------------------
 
@@ -175,6 +188,11 @@ Executes the Python interactive interpreter in a virtualenv after installing the
 ``fades -d django -x django-admin.py startproject foo``
 
 Uses the ``django-admin.py`` script to start a new project named ``foo``, without having to have django previously installed.
+
+``fades -d django --rm``
+
+Executes the Python interactive interpreter in a virtualenv with ``django`` installed and removes the virtualenv
+from disk once the interpreter is exited.
 
 
 How to install it

--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ dependencies. There are cases however when you'll want to do some clean up to re
 unnecessary virtual environments from disk.
 
 By running *fades* with the ``--rm`` argument, *fades* will remove the virtualenv
-matching the requirements after running the script or command specified.
+matching the provided uuid if such a virtualenv exists.
 
 
 Some command line examples
@@ -189,10 +189,9 @@ Executes the Python interactive interpreter in a virtualenv after installing the
 
 Uses the ``django-admin.py`` script to start a new project named ``foo``, without having to have django previously installed.
 
-``fades -d django --rm``
+``fades --rm 89a2bf83-c280-4918-a78d-c35506efd69d``
 
-Executes the Python interactive interpreter in a virtualenv with ``django`` installed and removes the virtualenv
-from disk once the interpreter is exited.
+Removes a virtualenv matching the given uuid from disk and cache index.
 
 
 How to install it

--- a/fades/cache.py
+++ b/fades/cache.py
@@ -17,10 +17,12 @@
 
 """The cache manager for virtualenvs."""
 
+import fcntl
 import json
 import logging
 import os
 import time
+from contextlib import contextmanager
 
 from pkg_resources import Distribution
 
@@ -84,12 +86,7 @@ class VEnvsCache:
 
     def get_venv(self, requirements, interpreter):
         """Find a venv that serves these requirements, if any."""
-        if os.path.exists(self.filepath):
-            with open(self.filepath, 'rt', encoding='utf8') as fh:
-                lines = [x.strip() for x in fh]
-        else:
-            logger.debug("Index not found, starting empty")
-            lines = []
+        lines = self._read_cache()
         return self._select(lines, requirements, interpreter)
 
     def store(self, installed_stuff, metadata, interpreter):
@@ -102,5 +99,42 @@ class VEnvsCache:
         }
         logger.debug("Storing installed=%s metadata=%s interpreter=%s",
                      installed_stuff, metadata, interpreter)
-        with open(self.filepath, 'at', encoding='utf8') as fh:
-            fh.write(json.dumps(new_content) + '\n')
+        with self.lock_cache():
+            self._write_cache([json.dumps(new_content)], append=True)
+
+    def remove(self, env_path):
+        """Remove metadata for a given virtualenv from cache."""
+        with self.lock_cache():
+            cache = self._read_cache()
+            logger.debug("Removing virtualenv from cache: %s" % env_path)
+            lines = [
+                line for line in cache
+                if json.loads(line).get('metadata', {}).get('env_path') != env_path
+            ]
+            self._write_cache(lines)
+
+    @contextmanager
+    def lock_cache(self):
+        lock_file = self.filepath + '.lock'
+        with open(lock_file, 'a') as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            yield
+            fcntl.flock(fh, fcntl.LOCK_UN)
+        if os.path.exists(lock_file):
+            os.remove(lock_file)
+
+    def _read_cache(self):
+        """Read virtualenv metadata from cache."""
+        if os.path.exists(self.filepath):
+            with open(self.filepath, 'rt', encoding='utf8') as fh:
+                lines = [x.strip() for x in fh]
+        else:
+            logger.debug("Index not found, starting empty")
+            lines = []
+        return lines
+
+    def _write_cache(self, lines, append=False):
+        """Write virtualenv metadata to cache."""
+        mode = 'at' if append else 'wt'
+        with open(self.filepath, mode, encoding='utf8') as fh:
+            fh.writelines(line + '\n' for line in lines)

--- a/fades/envbuilder.py
+++ b/fades/envbuilder.py
@@ -23,6 +23,7 @@ other python versions Fades needs a virtualenv tool installed.
 
 import logging
 import os
+import shutil
 
 from venv import EnvBuilder
 from uuid import uuid4
@@ -36,9 +37,11 @@ logger = logging.getLogger(__name__)
 
 class FadesEnvBuilder(EnvBuilder):
     """Create always a virtualenv."""
-    def __init__(self):
+    def __init__(self, env_path=None):
         basedir = helpers.get_basedir()
-        self.env_path = os.path.join(basedir, str(uuid4()))
+        if env_path is None:
+            env_path = os.path.join(basedir, str(uuid4()))
+        self.env_path = env_path
         self.env_bin_path = ''
         logger.debug("Env will be created at: %s", self.env_path)
 
@@ -80,6 +83,11 @@ class FadesEnvBuilder(EnvBuilder):
         logger.debug("env_bin_path: %s", self.env_bin_path)
         return self.env_path, self.env_bin_path, self.pip_installed
 
+    def destroy_env(self):
+        """Destroy the virtualenv."""
+        logger.debug("Destroying virtualenv at: %s", self.env_path)
+        shutil.rmtree(self.env_path, ignore_errors=True)
+
     def post_setup(self, context):
         """Gets the bin path from context."""
         self.env_bin_path = context.bin_path
@@ -118,3 +126,8 @@ def create_venv(requested_deps, interpreter, is_current):
 
         logger.debug("Installed dependencies: %s", installed)
     return venv_data, installed
+
+
+def destroy_venv(env_path):
+    env = FadesEnvBuilder(env_path)
+    env.destroy_env()

--- a/fades/main.py
+++ b/fades/main.py
@@ -188,3 +188,6 @@ def go(version, argv):
         if env_path:
             venvscache.remove(env_path)
             envbuilder.destroy_venv(env_path)
+        else:
+            l.warning("Invalid 'env_path' found in virtualenv metadata: %r. "
+                      "Not removing virtualenv.", env_path)

--- a/fades/main.py
+++ b/fades/main.py
@@ -184,5 +184,7 @@ def go(version, argv):
 
     if args.remove:
         # remove this venv from the cache
-        venvscache.remove(venv_data)
-        envbuilder.destroy_venv(venv_data)
+        env_path = venv_data.get('env_path')
+        if env_path:
+            venvscache.remove(env_path)
+            envbuilder.destroy_venv(env_path)

--- a/fades/main.py
+++ b/fades/main.py
@@ -86,6 +86,8 @@ def go(version, argv):
                         help=("Indicate that the child_program should be looked up in the "
                               "virtualenv."))
     parser.add_argument('-i', '--ipython', action='store_true', help="use IPython shell.")
+    parser.add_argument('--rm', action='store_true', dest='remove',
+                        help=("Remove the virtualenv after running the child program."))
     parser.add_argument('child_program', nargs='?', default=None)
     parser.add_argument('child_options', nargs=argparse.REMAINDER)
 
@@ -179,3 +181,8 @@ def go(version, argv):
     rc = p.wait()
     if rc:
         l.debug("Child process not finished correctly: returncode=%d", rc)
+
+    if args.remove:
+        # remove this venv from the cache
+        venvscache.remove(venv_data)
+        envbuilder.destroy_venv(venv_data)

--- a/man/fades.1
+++ b/man/fades.1
@@ -68,6 +68,14 @@ Select which Python version to be used; the argument can be just the number (2.7
 
 The dependencies can be indicated in multiple places (in the Python source file, with a comment besides the import, in a \fIrequirements\fRfile, and/or through command line. In case of multiple definitions of the same dependency, command line overrides everything else, and requirements file overrides what is specified in the source code.
 
+.TP
+.BR -x ", " --exec
+Look up the \fIchild_program\fR in the virtualenv.
+
+.TP
+.BR --rm
+Remove the virtualenv after executing the \fIchild_program\fR.
+
 .SH EXAMPLES
 
 .TP

--- a/man/fades.1
+++ b/man/fades.1
@@ -75,8 +75,8 @@ Execute the \fIchild_program\fR inside the virtualenv.
 The \fIchild_program\fR \fBmust\fR be found in the virtualenv's \fIbin\fR directory.
 
 .TP
-.BR --rm
-Remove the virtualenv after executing the \fIchild_program\fR.
+.BR --rm " " \fIuuid\fR
+Remove a virtualenv by uuid.
 
 .SH EXAMPLES
 

--- a/man/fades.1
+++ b/man/fades.1
@@ -70,7 +70,9 @@ The dependencies can be indicated in multiple places (in the Python source file,
 
 .TP
 .BR -x ", " --exec
-Look up the \fIchild_program\fR in the virtualenv.
+Execute the \fIchild_program\fR inside the virtualenv.
+
+The \fIchild_program\fR \fBmust\fR be found in the virtualenv's \fIbin\fR directory.
 
 .TP
 .BR --rm

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -19,8 +19,9 @@
 import json
 import os
 import tempfile
+import time
 import unittest
-
+from threading import Thread
 from unittest.mock import patch
 
 from pkg_resources import parse_requirements
@@ -103,6 +104,83 @@ class StoreTestCase(TempfileTestCase):
             self.assertEqual(data['installed'], 'installed')
             self.assertEqual(data['metadata'], 'metadata')
             self.assertEqual(data['interpreter'], 'interpreter')
+
+
+class RemoveTestCase(TempfileTestCase):
+    """Remove virtualenv from cache."""
+
+    def test_missing_file(self):
+        venvscache = cache.VEnvsCache(self.tempfile)
+        venvscache.remove('missing/path')
+
+        lines = venvscache._read_cache()
+        self.assertEqual(lines, [])
+
+    def test_missing_env_in_cache(self):
+        venvscache = cache.VEnvsCache(self.tempfile)
+        venvscache.store('installed', {'env_path': 'some/path'}, 'interpreter')
+        lines = venvscache._read_cache()
+        assert len(lines) == 1
+
+        venvscache.remove('some/path')
+
+        lines = venvscache._read_cache()
+        self.assertEqual(lines, [])
+
+    def test_preserve_cache_data_ordering(self):
+        venvscache = cache.VEnvsCache(self.tempfile)
+        # store 3 venvs
+        venvscache.store('installed1', {'env_path': 'path/env1'}, 'interpreter')
+        venvscache.store('installed2', {'env_path': 'path/env2'}, 'interpreter')
+        venvscache.store('installed3', {'env_path': 'path/env3'}, 'interpreter')
+
+        venvscache.remove('path/env2')
+
+        lines = venvscache._read_cache()
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(
+            json.loads(lines[0]).get('metadata').get('env_path'), 'path/env1')
+        self.assertEqual(
+            json.loads(lines[1]).get('metadata').get('env_path'), 'path/env3')
+
+    def test_lock_cache_for_remove(self):
+        venvscache = cache.VEnvsCache(self.tempfile)
+        # store 3 venvs
+        venvscache.store('installed1', {'env_path': 'path/env1'}, 'interpreter')
+        venvscache.store('installed2', {'env_path': 'path/env2'}, 'interpreter')
+        venvscache.store('installed3', {'env_path': 'path/env3'}, 'interpreter')
+
+        # patch _write_cache so it emulates a slow write during which
+        # another process managed to modify the cache file before the
+        # first process finished writing the modified cache data
+        original_write_cache = venvscache._write_cache
+        p = patch('fades.cache.VEnvsCache._write_cache')
+        mock_write_cache = p.start()
+
+        t1 = Thread(target=venvscache.remove, args=('path/env1',))
+
+        def slow_write_cache(*args, **kwargs):
+            p.stop()
+            t1.start()
+            # wait to ensure t1 thread must wait for lock to be released
+            time.sleep(0.01)
+            original_write_cache(*args, **kwargs)
+
+        mock_write_cache.side_effect = slow_write_cache
+
+        # just a sanity check
+        assert not os.path.exists(venvscache.filepath + '.lock')
+        # remove a virtualenv from the cache
+        venvscache.remove('path/env2')
+        t1.join()
+
+        # when cache file is properly locked both virtualenvs
+        # will have been removed from the cache
+        lines = venvscache._read_cache()
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(
+            json.loads(lines[0]).get('metadata').get('env_path'), 'path/env3')
+        self.assertFalse(os.path.exists(venvscache.filepath + '.lock'))
 
 
 class SelectionTestCase(TempfileTestCase):

--- a/tests/test_envbuilder.py
+++ b/tests/test_envbuilder.py
@@ -16,6 +16,7 @@
 
 """Tests for the venv builder module."""
 
+import os
 import unittest
 
 from unittest.mock import patch
@@ -108,3 +109,35 @@ class EnvCreationTestCase(unittest.TestCase):
                 'dep2': 'v2',
             }
         })
+
+    def test_custom_env_path(self):
+        builder = envbuilder.FadesEnvBuilder('some-path')
+        self.assertEqual(builder.env_path, 'some-path')
+
+
+class EnvDestructionTestCase(unittest.TestCase):
+
+    def test_destroy_env(self):
+        builder = envbuilder.FadesEnvBuilder()
+        # make sure the virtualenv exists on disk
+        builder.create_env('python', False)
+        assert os.path.exists(builder.env_path)
+
+        builder.destroy_env()
+        self.assertFalse(os.path.exists(builder.env_path))
+
+    def test_destroy_venv(self):
+        builder = envbuilder.FadesEnvBuilder()
+        # make sure the virtualenv exists on disk
+        builder.create_env('python', False)
+        assert os.path.exists(builder.env_path)
+
+        envbuilder.destroy_venv(builder.env_path)
+        self.assertFalse(os.path.exists(builder.env_path))
+
+    def test_destroy_venv_if_env_path_not_found(self):
+        builder = envbuilder.FadesEnvBuilder()
+        assert not os.path.exists(builder.env_path)
+
+        envbuilder.destroy_venv(builder.env_path)
+        self.assertFalse(os.path.exists(builder.env_path))


### PR DESCRIPTION
This PR introduces a new --rm flag for fades that allows it to remove the virtualenv matching the specified dependencies.