### PR TITLE
set define enconding  PEP 0263

### DIFF
--- a/bin/fades
+++ b/bin/fades
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 #
 # Copyright 2014 Facundo Batista, Nicolás Demarchi

--- a/fades/__init__.py
+++ b/fades/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify

--- a/fades/cache.py
+++ b/fades/cache.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify

--- a/fades/envbuilder.py
+++ b/fades/envbuilder.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/file_options.py
+++ b/fades/file_options.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/helpers.py
+++ b/fades/helpers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014-2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/logger.py
+++ b/fades/logger.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/main.py
+++ b/fades/main.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014-2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify

--- a/fades/multiplatform.py
+++ b/fades/multiplatform.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify

--- a/fades/parsing.py
+++ b/fades/parsing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014, 2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014, 2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/pkgnamesdb.py
+++ b/fades/pkgnamesdb.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/tests/test_files/no_req.py
+++ b/tests/test_files/no_req.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/tests/test_files/req_all.py
+++ b/tests/test_files/req_all.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/tests/test_files/req_class.py
+++ b/tests/test_files/req_class.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/tests/test_files/req_module.py
+++ b/tests/test_files/req_module.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/tests/test_files/req_module_2.py
+++ b/tests/test_files/req_module_2.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/tests/test_files/req_module_3.py
+++ b/tests/test_files/req_module_3.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it


### PR DESCRIPTION
In a Debian 8, installed by pip. When is execute fades 

<code>
  File "/usr/local/bin/fades", line 4
SyntaxError: Non-ASCII character '\xc3' in file /usr/local/bin/fades on line 4, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
</code>


This PR add define encoding by PEP 0263

