### PR TITLE
Clean old venvs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,10 +164,6 @@ If you want to use IPython shell you need to call *fades* with ``-i`` or
 ``--ipython`` option. This option will add IPython as a dependency to *fades*
 and it will launch this shell instead of the python one.
 
-If you want to remove unused virtualenvs you need to call *fades* with ``--clean-unused-venvs``.
-All virtualenvs that haven't been used for more days than the value indicated in param will be removed.
-Appart from that, will compact usage stats file.
-
 You can also use ``--system-site-packages`` to create a venv with access to the system libs.
 
 
@@ -256,6 +252,17 @@ unnecessary virtual environments from disk.
 By running *fades* with the ``--rm`` argument, *fades* will remove the virtualenv
 matching the provided uuid if such a virtualenv exists.
 
+Another way to clean up the cache is to remove all venvs that haven't been used for some time.
+In order to do this you need to call *fades* with ``--clean-unused-venvs``.
+When fades it's called with this option, it runs in mantain mode, this means that fades will exit
+after finished this task.
+All virtualenvs that haven't been used for more days than the value indicated in param will be
+removed.
+
+It is recommended to have some automatically way of run this option;
+ie, add a cron task that perform this command::
+
+    fades --clean-unused-venvs=42
 
 Some command line examples
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,10 @@ If you want to use IPython shell you need to call *fades* with ``-i`` or
 ``--ipython`` option. This option will add IPython as a dependency to *fades*
 and it will launch this shell instead of the python one.
 
+If you want to remove unused virtualenvs you need to call *fades* with ``--clean-unused-venvs``.
+All virtualenvs that haven't been used for more days than the value indicated in param will be removed.
+Appart from that, will compact usage stats file.
+
 You can also use ``--system-site-packages`` to create a venv with access to the system libs.
 
 

--- a/fades/cache.py
+++ b/fades/cache.py
@@ -107,6 +107,7 @@ class VEnvsCache:
         return self._select(lines, requirements, interpreter, uuid=uuid, options=options)
 
     def get_venvs_metadata(self):
+        """Yield metadata of each existing venv."""
         for line in self._read_cache():
             yield json.loads(line)['metadata']
 

--- a/fades/cache.py
+++ b/fades/cache.py
@@ -106,6 +106,10 @@ class VEnvsCache:
         lines = self._read_cache()
         return self._select(lines, requirements, interpreter, uuid=uuid, options=options)
 
+    def get_venvs_metadata(self):
+        for line in self._read_cache():
+            yield json.loads(line)['metadata']
+
     def store(self, installed_stuff, metadata, interpreter, options):
         """Store the virtualenv metadata for the indicated installed_stuff."""
         new_content = {

--- a/fades/cache.py
+++ b/fades/cache.py
@@ -24,7 +24,6 @@ import time
 
 from pkg_resources import Distribution
 
-from fades import helpers
 from fades.multiplatform import filelock
 
 logger = logging.getLogger(__name__)
@@ -77,8 +76,12 @@ class VEnvsCache:
 
     def _select(self, current_venvs, requirements=None, interpreter='', uuid='', options=None):
         """Select which venv satisfy the received requirements."""
-        def match_by_uuid(env):
-            return env.get('metadata', {}).get('env_path') == env_path
+        def get_match_by_uuid(uuid):
+            def match_by_uuid(env):
+                env_path = env.get('metadata', {}).get('env_path')
+                _, env_uuid = os.path.split(env_path)
+                return env_uuid == uuid
+            return match_by_uuid
 
         def match_by_req_and_interpreter(env):
             return (env.get('options') == options and
@@ -87,8 +90,7 @@ class VEnvsCache:
 
         if uuid:
             logger.debug("Searching a venv by uuid: %s", uuid)
-            env_path = os.path.join(helpers.get_basedir(), uuid)
-            match = match_by_uuid
+            match = get_match_by_uuid(uuid)
         else:
             logger.debug("Searching a venv for reqs: %s and interpreter: %s",
                          requirements, interpreter)

--- a/fades/envbuilder.py
+++ b/fades/envbuilder.py
@@ -160,7 +160,10 @@ def destroy_venv(env_path):
 
 
 class UsageManager:
+    """Class to handle usage file and venv cleanning."""
+
     def __init__(self, venvscache):
+        """Init."""
         self.stat_file_path = os.path.join(helpers.get_basedir(), 'usage_stats')
         self.stat_file_lock = self.stat_file_path + '.lock'
         self.venvscache = venvscache
@@ -190,10 +193,7 @@ class UsageManager:
         return datetime.strptime(str_, "%Y-%m-%dT%H:%M:%S.%f")
 
     def clean_unused_venvs(self, max_days_to_keep):
-        """
-        Compact usage stats and remove venvs that have not been used for more max_days_to_keep
-        days.
-        """
+        """Compact usage stats and remove venvs."""
         with filelock(self.stat_file_lock):
             now = datetime.utcnow()
             venvs_dict = self._get_compacted_dict_usage_from_file()

--- a/fades/envbuilder.py
+++ b/fades/envbuilder.py
@@ -162,10 +162,10 @@ def destroy_venv(env_path):
 class UsageManager:
     """Class to handle usage file and venv cleanning."""
 
-    def __init__(self, venvscache):
+    def __init__(self, stat_file_path, venvscache):
         """Init."""
-        self.stat_file_path = os.path.join(helpers.get_basedir(), 'usage_stats')
-        self.stat_file_lock = self.stat_file_path + '.lock'
+        self.stat_file_path = stat_file_path
+        self.stat_file_lock = stat_file_path + '.lock'
         self.venvscache = venvscache
         self._create_initial_usage_file_if_not_exists()
 
@@ -183,8 +183,7 @@ class UsageManager:
 
     def _write_venv_usage(self, file_, venv_data):
         _, uuid = os.path.split(venv_data['env_path'])
-        file_.write('{} {}\n'.format(uuid,
-                                     self._datetime_to_str(datetime.utcnow())))
+        file_.write('{} {}\n'.format(uuid, self._datetime_to_str(datetime.utcnow())))
 
     def _datetime_to_str(self, datetime_):
         return datetime.strftime(datetime_, "%Y-%m-%dT%H:%M:%S.%f")

--- a/fades/envbuilder.py
+++ b/fades/envbuilder.py
@@ -159,24 +159,22 @@ def destroy_venv(env_path):
 
 
 class UsageManager:
-    def store_usage_stat(self, venv_data, cache):
-        """
-        Log an usage record for venv_data.
-        If usage_stats file doesn't exists, manager will create it and log an usage record for
-        every existing virtualenv in cache.
-        """
-        stat_file_path = os.path.join(helpers.get_basedir(), 'usage_stats')
-        if not os.path.exists(stat_file_path):
-            self._create_initial_usage_file(stat_file_path, cache)
-        else:
-            with open(stat_file_path, 'at') as f:
-                self._write_venv_usage(f, venv_data)
+    def __init__(self, venvscache):
+        self.stat_file_path = os.path.join(helpers.get_basedir(), 'usage_stats')
+        self.venvscache = venvscache
+        self._create_initial_usage_file_if_not_exists()
 
-    def _create_initial_usage_file(self, path, cache):
-        existing_venvs = cache.get_venvs_metadata()
-        with open(path, 'wt') as f:
-            for venv_data in existing_venvs:
-                self._write_venv_usage(f, venv_data)
+    def store_usage_stat(self, venv_data, cache):
+        """Log an usage record for venv_data."""
+        with open(self.stat_file_path, 'at') as f:
+            self._write_venv_usage(f, venv_data)
+
+    def _create_initial_usage_file_if_not_exists(self):
+        if not os.path.exists(self.stat_file_path):
+            existing_venvs = self.venvscache.get_venvs_metadata()
+            with open(self.stat_file_path, 'wt') as f:
+                for venv_data in existing_venvs:
+                    self._write_venv_usage(f, venv_data)
 
     def _write_venv_usage(self, file_, venv_data):
         _, uuid = os.path.split(venv_data['env_path'])

--- a/fades/main.py
+++ b/fades/main.py
@@ -150,6 +150,8 @@ def go(argv):
         except:
             l.debug("CLEAN_UNUSED_VENVS must be an integer.")
             raise
+        finally:
+            sys.exit()
 
     uuid = args.remove
     if uuid:

--- a/fades/main.py
+++ b/fades/main.py
@@ -143,6 +143,14 @@ def go(argv):
     # start usage manager
     usage_manager = envbuilder.UsageManager(venvscache)
 
+    if args.clean_unused_venvs:
+        try:
+            max_days_to_keep = int(args.clean_unused_venvs)
+            usage_manager.clean_unused_venvs(max_days_to_keep)
+        except:
+            l.debug("CLEAN_UNUSED_VENVS must be an integer.")
+            raise
+
     uuid = args.remove
     if uuid:
         venv_data = venvscache.get_venv(uuid=uuid)

--- a/fades/main.py
+++ b/fades/main.py
@@ -161,8 +161,7 @@ def go(argv):
             # remove this venv from the cache
             env_path = venv_data.get('env_path')
             if env_path:
-                venvscache.remove(env_path)
-                envbuilder.destroy_venv(env_path)
+                envbuilder.destroy_venv(env_path, venvscache)
             else:
                 l.warning("Invalid 'env_path' found in virtualenv metadata: %r. "
                           "Not removing virtualenv.", env_path)

--- a/fades/main.py
+++ b/fades/main.py
@@ -140,6 +140,8 @@ def go(argv):
 
     # start the virtualenvs manager
     venvscache = cache.VEnvsCache(os.path.join(helpers.get_basedir(), 'venvs.idx'))
+    # start usage manager
+    usage_manager = envbuilder.UsageManager(venvscache)
 
     uuid = args.remove
     if uuid:
@@ -208,8 +210,7 @@ def go(argv):
     python_exe = 'ipython' if args.ipython else 'python'
     python_exe = os.path.join(venv_data['env_bin_path'], python_exe)
 
-    # start usage manager and store usage information
-    usage_manager = envbuilder.UsageManager()
+    # store usage information
     usage_manager.store_usage_stat(venv_data, venvscache)
 
     if args.child_program is None:

--- a/fades/main.py
+++ b/fades/main.py
@@ -100,6 +100,12 @@ def go(argv):
                               "used multiple times)"))
     parser.add_argument('--rm', dest='remove', metavar='UUID',
                         help=("Remove a virtualenv by UUID."))
+    parser.add_argument('--clean-unused-venvs', action='store',
+                        help=("This option remove venvs that haven't been used for more than "
+                              "CLEAN_UNUSED_VENVS days. Appart from that, will compact usage "
+                              "stats file.\n"
+                              "When this option is present, the cleaning takes place at the "
+                              "beginning of the execution."))
     parser.add_argument('child_program', nargs='?', default=None)
     parser.add_argument('child_options', nargs=argparse.REMAINDER)
 

--- a/fades/main.py
+++ b/fades/main.py
@@ -141,7 +141,8 @@ def go(argv):
     # start the virtualenvs manager
     venvscache = cache.VEnvsCache(os.path.join(helpers.get_basedir(), 'venvs.idx'))
     # start usage manager
-    usage_manager = envbuilder.UsageManager(venvscache)
+    usage_manager = envbuilder.UsageManager(os.path.join(helpers.get_basedir(), 'usage_stats'),
+                                            venvscache)
 
     if args.clean_unused_venvs:
         try:

--- a/fades/main.py
+++ b/fades/main.py
@@ -201,6 +201,11 @@ def go(argv):
     # run forest run!!
     python_exe = 'ipython' if args.ipython else 'python'
     python_exe = os.path.join(venv_data['env_bin_path'], python_exe)
+
+    # start usage manager and store usage information
+    usage_manager = envbuilder.UsageManager()
+    usage_manager.store_usage_stat(venv_data, venvscache)
+
     if args.child_program is None:
         l.debug("Calling the interactive Python interpreter")
         p = subprocess.Popen([python_exe])

--- a/man/fades.1
+++ b/man/fades.1
@@ -19,6 +19,7 @@ fades - A system that automatically handles the virtualenvs in the cases normall
 [\fB--virtualenv-options\fR=\fIoptions\fR]
 [\fB--pip-options\fR=\fIoptions\fR]
 [\fB--check-updates\fR]
+[\fB--clean-unused-venvs\fR=\fImax_days_to_keep\fR]
 [child_program [child_options]]
 
 \fBfades\fR can be used to execute directly your script, or put it with a #! at your script's beginning.
@@ -99,6 +100,10 @@ Extra options to be supplied to pip. (this option can beused multiple times)
 .TP 
 .BR --check-updates
 Will check for updates in PyPI to verify if there are new versions for the requested dependencies. If a new version is available for a dependency, it will use it (if the dependency was requested without version) or just inform which new version is available (if the dependency was requested with a specific version).
+
+.TP
+.BR --clean-unused-venvs=\fIMAX_DAYS_TO_KEEP\fR
+Will remove all virtualenvs that haven't been used for more than MAX_DAYS_TO_KEEP days. Appart from that, will compact usage stats file.
 
 .SH EXAMPLES
 

--- a/man/fades.1
+++ b/man/fades.1
@@ -103,7 +103,7 @@ Will check for updates in PyPI to verify if there are new versions for the reque
 
 .TP
 .BR --clean-unused-venvs=\fIMAX_DAYS_TO_KEEP\fR
-Will remove all virtualenvs that haven't been used for more than MAX_DAYS_TO_KEEP days. Appart from that, will compact usage stats file.
+Will remove all virtualenvs that haven't been used for more than MAX_DAYS_TO_KEEP days.
 
 .SH EXAMPLES
 

--- a/tests/test_envbuilder.py
+++ b/tests/test_envbuilder.py
@@ -221,11 +221,6 @@ class UsageManagerTestCase(unittest.TestCase):
         self.file_path = os.path.join(self.temp_folder, 'usage_stats')
         self.addCleanup(lambda: os.path.exists(self.tempfile) and os.remove(self.tempfile))
 
-        self.mock_base_dir = patch('fades.helpers.get_basedir')
-        base_dir = self.mock_base_dir.start()
-        base_dir.return_value = self.temp_folder
-        self.addCleanup(lambda: self.mock_base_dir.stop())
-
         self.uuids = ['env1', 'env2', 'env3']
 
         self.venvscache = cache.VEnvsCache(self.tempfile)
@@ -243,7 +238,7 @@ class UsageManagerTestCase(unittest.TestCase):
 
     def test_file_usage_dont_exists_then_it_is_created_and_initialized(self):
         self.assertFalse(os.path.exists(self.file_path), msg="First file doesn't exists")
-        manager = envbuilder.UsageManager(self.venvscache)
+        manager = envbuilder.UsageManager(self.file_path, self.venvscache)
         lines = self.get_usage_lines(manager)
         self.assertEqual(len(lines), len(self.uuids), msg="File have one line per venv")
 
@@ -253,7 +248,7 @@ class UsageManagerTestCase(unittest.TestCase):
             pending_uuids.remove(uuid)
 
     def test_usage_record_is_recorded(self):
-        manager = envbuilder.UsageManager(self.venvscache)
+        manager = envbuilder.UsageManager(self.file_path, self.venvscache)
         lines = self.get_usage_lines(manager)
         self.assertEqual(len(lines), len(self.uuids), msg="File have one line per venv")
 
@@ -273,7 +268,7 @@ class UsageManagerTestCase(unittest.TestCase):
             mock_datetime.strptime.side_effect = lambda *args, **kw: datetime.strptime(*args, **kw)
             mock_datetime.strftime.side_effect = lambda *args, **kw: datetime.strftime(*args, **kw)
 
-            manager = envbuilder.UsageManager(self.venvscache)
+            manager = envbuilder.UsageManager(self.file_path, self.venvscache)
             lines = self.get_usage_lines(manager)
             for u, d in lines:
                 self.assertEqual(old_date, d, msg="All records have the same date")
@@ -306,7 +301,7 @@ class UsageManagerTestCase(unittest.TestCase):
             mock_datetime.strptime.side_effect = lambda *args, **kw: datetime.strptime(*args, **kw)
             mock_datetime.strftime.side_effect = lambda *args, **kw: datetime.strftime(*args, **kw)
 
-            manager = envbuilder.UsageManager(self.venvscache)
+            manager = envbuilder.UsageManager(self.file_path, self.venvscache)
             lines = self.get_usage_lines(manager)
             for u, d in lines:
                 self.assertEqual(old_date, d, msg="All records have the same date")


### PR DESCRIPTION
Hi, this PR is related to issue #170. 

With this pull request i've added this behaviors:
* When fades is invoked, always test the existence of usage_stats file. If it doesn't exists, it's created and filled with all the current venvs in cache.

* When venv it's used one line is recorded in usage file. This line contains the venv's uuid and datetime of usage.

* When fades is called with the option *--clean-unused-venvs=X*; after the first check, the usage file is compacted and all venvs that haven't been used for more than X days are removed. That's mean, remove from usage stat file, from index and the fisical env.
