### PR TITLE
if no cache in params, then only remove folder. Fix test

### DIFF
--- a/fades/envbuilder.py
+++ b/fades/envbuilder.py
@@ -158,12 +158,13 @@ def create_venv(requested_deps, interpreter, is_current, options, pip_options):
     return venv_data, installed
 
 
-def destroy_venv(env_path, venvscache):
+def destroy_venv(env_path, venvscache=None):
     """Destroy a venv."""
     env = FadesEnvBuilder(env_path)
     env.destroy_env()
     # remove venv from cache
-    venvscache.remove(env_path)
+    if venvscache is not None:
+        venvscache.remove(env_path)
 
 
 class UsageManager:

--- a/tests/test_envbuilder.py
+++ b/tests/test_envbuilder.py
@@ -120,15 +120,15 @@ class EnvCreationTestCase(unittest.TestCase):
             with patch.object(envbuilder, 'PipManager') as mock_mgr_c:
                 mock_create.return_value = ('env_path', 'env_bin_path', 'pip_installed')
                 mock_mgr_c.return_value = self.FailInstallManager()
-                with self.assertRaises(SystemExit):
-                    with patch.object(envbuilder, 'destroy_venv') as mock_destroy:
+                with patch.object(envbuilder, 'destroy_venv', spec=True) as mock_destroy:
+                    with self.assertRaises(SystemExit):
                         envbuilder.create_venv(
                             requested,
                             interpreter,
                             is_current,
                             options,
                             pip_options)
-                        mock_destroy.assert_called_once_with('env_path')
+                    mock_destroy.assert_called_once_with('env_path')
 
         self.assertLoggedDebug("Installation Step failed, removing virtualenv")
 


### PR DESCRIPTION
When a dependency fail to be installed, the process call to destroy_venv with no cache parameter and fails.

This problem was not detected by tests because the assert was in the same scope where the exception it's captured. 