### PR TITLE
Add utf-8 encoding declaration to all files

### DIFF
--- a/bin/fades
+++ b/bin/fades
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 #
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
@@ -22,7 +23,7 @@
 import os
 import sys
 
-# small hack to allow fades to be run directly from the project, using code 
+# small hack to allow fades to be run directly from the project, using code
 # from project itself, not anything already installed in the system
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(sys.argv[0])))
 if os.path.basename(parent_dir) == 'fades':

--- a/fades/__init__.py
+++ b/fades/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015-2016 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify

--- a/fades/__main__.py
+++ b/fades/__main__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Init file to allow execution of fades as a module."""
 
 import sys

--- a/fades/_version.py
+++ b/fades/_version.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Holder of the fades version number."""
 
 VERSION = (5, 0)

--- a/fades/cache.py
+++ b/fades/cache.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015-2016 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify

--- a/fades/envbuilder.py
+++ b/fades/envbuilder.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014-2016 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/file_options.py
+++ b/fades/file_options.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/helpers.py
+++ b/fades/helpers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014-2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/logger.py
+++ b/fades/logger.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/main.py
+++ b/fades/main.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014-2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify

--- a/fades/multiplatform.py
+++ b/fades/multiplatform.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify

--- a/fades/parsing.py
+++ b/fades/parsing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014-2016 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2014-2016 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/fades/pkgnamesdb.py
+++ b/fades/pkgnamesdb.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it


### PR DESCRIPTION
Docstring of the files contain a name with non ascii character requires to add the encoding declaration

Otherwise, trying to run fades gives:
```
$ fades -d django
  File "/usr/local/bin/fades", line 4
SyntaxError: Non-ASCII character '\xc3' in file /usr/local/bin/fades on line 4, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```