### PR TITLE
Cleanup if pip download fails

### DIFF
--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -59,7 +59,7 @@ class PipManager():
         if not self.pip_installed:
             logger.info("Need to install a dependency with pip, but no builtin, "
                         "doing it manually (just wait a little, all should go well)")
-            self.brute_force_install_pip()
+            self._brute_force_install_pip()
 
         str_dep = str(dependency)
         args = [self.pip_exe, "install", str_dep]
@@ -90,21 +90,21 @@ class PipManager():
                          'Run with -v or check the logs for details')
             return ''
 
-    def download_pip_installer(self):
+    def _download_pip_installer(self):
         u = request.urlopen(PIP_INSTALLER)
         temp_location = self.pip_installer_fname + '.temp'
         with contextlib.closing(u), open(temp_location, 'wb') as f:
             shutil.copyfileobj(u, f)
         os.rename(temp_location, self.pip_installer_fname)
 
-    def brute_force_install_pip(self):
+    def _brute_force_install_pip(self):
         """A brute force install of pip itself."""
         if os.path.exists(self.pip_installer_fname):
             logger.debug("Using pip installer from %r", self.pip_installer_fname)
         else:
             logger.debug(
                 "Installer for pip not found in %r, downloading it", self.pip_installer_fname)
-            self.download_pip_installer()
+            self._download_pip_installer()
 
         logger.debug("Installing PIP manually in the virtualenv")
         python_exe = os.path.join(self.env_bin_path, "python")

--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -92,8 +92,7 @@ class PipManager():
 
     def download_pip_installer(self):
         u = request.urlopen(PIP_INSTALLER)
-        with contextlib.closing(u), \
-                tempfile.NamedTemporaryFile('wb') as f:
+        with contextlib.closing(u), tempfile.NamedTemporaryFile('wb') as f:
             shutil.copyfileobj(u, f)
             f.flush()
             shutil.copy(f.name, self.pip_installer_fname)

--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -56,7 +56,7 @@ class PipManager():
         if not self.pip_installed:
             logger.info("Need to install a dependency with pip, but no builtin, "
                         "doing it manually (just wait a little, all should go well)")
-            self._brute_force_install_pip()
+            self.brute_force_install_pip()
 
         str_dep = str(dependency)
         args = [self.pip_exe, "install", str_dep]
@@ -87,7 +87,7 @@ class PipManager():
                          'Run with -v or check the logs for details')
             return ''
 
-    def _brute_force_install_pip(self):
+    def brute_force_install_pip(self):
         """A brute force install of pip itself."""
         if os.path.exists(self.pip_installer_fname):
             logger.debug("Using pip installer from %r", self.pip_installer_fname)

--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -92,10 +92,10 @@ class PipManager():
 
     def download_pip_installer(self):
         u = request.urlopen(PIP_INSTALLER)
-        with contextlib.closing(u), tempfile.NamedTemporaryFile('wb') as f:
+        temp_location = self.pip_installer_fname + '.temp'
+        with contextlib.closing(u), open(temp_location, 'wb') as f:
             shutil.copyfileobj(u, f)
-            f.flush()
-            shutil.copy(f.name, self.pip_installer_fname)
+        os.rename(temp_location, self.pip_installer_fname)
 
     def brute_force_install_pip(self):
         """A brute force install of pip itself."""

--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -87,6 +87,16 @@ class PipManager():
                          'Run with -v or check the logs for details')
             return ''
 
+    def download_pip_installer(self):
+        u = request.urlopen(PIP_INSTALLER)
+        try:
+            with open(self.pip_installer_fname, 'wb') as fh:
+                fh.write(u.read())
+        except:
+            if os.path.exists(self.pip_installer_fname):
+                os.remove(self.pip_installer_fname)
+            raise
+
     def brute_force_install_pip(self):
         """A brute force install of pip itself."""
         if os.path.exists(self.pip_installer_fname):
@@ -94,9 +104,7 @@ class PipManager():
         else:
             logger.debug(
                 "Installer for pip not found in %r, downloading it", self.pip_installer_fname)
-            u = request.urlopen(PIP_INSTALLER)
-            with open(self.pip_installer_fname, 'wb') as fh:
-                fh.write(u.read())
+            self.download_pip_installer()
 
         logger.debug("Installing PIP manually in the virtualenv")
         python_exe = os.path.join(self.env_bin_path, "python")

--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -23,6 +23,8 @@ the created virtualenv.
 
 import os
 import logging
+import shutil
+import tempfile
 
 from urllib import request
 
@@ -89,13 +91,10 @@ class PipManager():
 
     def download_pip_installer(self):
         u = request.urlopen(PIP_INSTALLER)
-        try:
-            with open(self.pip_installer_fname, 'wb') as fh:
-                fh.write(u.read())
-        except:
-            if os.path.exists(self.pip_installer_fname):
-                os.remove(self.pip_installer_fname)
-            raise
+        with tempfile.NamedTemporaryFile('wb') as f:
+            shutil.copyfileobj(u, f)
+            f.flush()
+            shutil.copy(f.name, self.pip_installer_fname)
 
     def brute_force_install_pip(self):
         """A brute force install of pip itself."""

--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -25,6 +25,7 @@ import os
 import logging
 import shutil
 import tempfile
+import contextlib
 
 from urllib import request
 
@@ -91,7 +92,8 @@ class PipManager():
 
     def download_pip_installer(self):
         u = request.urlopen(PIP_INSTALLER)
-        with tempfile.NamedTemporaryFile('wb') as f:
+        with contextlib.closing(u), \
+                tempfile.NamedTemporaryFile('wb') as f:
             shutil.copyfileobj(u, f)
             f.flush()
             shutil.copy(f.name, self.pip_installer_fname)

--- a/tests/test_pipmanager.py
+++ b/tests/test_pipmanager.py
@@ -102,7 +102,7 @@ class PipManagerTestCase(unittest.TestCase):
     def test_install_without_pip(self):
         mgr = PipManager('/usr/bin', pip_installed=False)
         with patch.object(helpers, 'logged_exec') as mocked_exec:
-            with patch.object(mgr, 'brute_force_install_pip') as mocked_install_pip:
+            with patch.object(mgr, '_brute_force_install_pip') as mocked_install_pip:
                 mgr.install('foo')
                 self.assertEqual(mocked_install_pip.call_count, 1)
             mocked_exec.assert_called_with(['/usr/bin/pip', 'install', 'foo'])
@@ -121,7 +121,7 @@ class PipManagerTestCase(unittest.TestCase):
         with patch.object(helpers, 'logged_exec') as mocked_exec:
             with patch('os.path.exists') as os_exists:
                 os_exists.return_value = True
-                mgr.brute_force_install_pip()
+                mgr._brute_force_install_pip()
 
                 os_exists.assert_called_once_with(mgr.pip_installer_fname)
             mocked_exec.assert_called_with(['/usr/bin/python', mgr.pip_installer_fname, '-I'])
@@ -131,9 +131,9 @@ class PipManagerTestCase(unittest.TestCase):
         mgr = PipManager('/usr/bin', pip_installed=False)
         with patch.object(helpers, 'logged_exec') as mocked_exec:
             with patch('os.path.exists') as os_exists:
-                with patch.object(mgr, 'download_pip_installer') as download_installer:
+                with patch.object(mgr, '_download_pip_installer') as download_installer:
                     os_exists.return_value = False
-                    mgr.brute_force_install_pip()
+                    mgr._brute_force_install_pip()
 
                     os_exists.assert_called_once_with(mgr.pip_installer_fname)
                     download_installer.assert_called_once_with()
@@ -146,6 +146,6 @@ class PipManagerTestCase(unittest.TestCase):
             mgr.pip_installer_fname = temp_file.name
             with patch('fades.pipmanager.request.urlopen') as urlopen:
                 urlopen.return_value = io.BytesIO(b'hola')
-                mgr.download_pip_installer()
+                mgr._download_pip_installer()
             self.assertTrue(os.path.exists(mgr.pip_installer_fname))
         urlopen.assert_called_once_with(pipmanager.PIP_INSTALLER)

--- a/tests/test_pipmanager.py
+++ b/tests/test_pipmanager.py
@@ -121,3 +121,16 @@ class PipManagerTestCase(unittest.TestCase):
                 os_exists.assert_called_once_with(mgr.pip_installer_fname)
             mocked_exec.assert_called_with(['/usr/bin/python', mgr.pip_installer_fname, '-I'])
         self.assertTrue(mgr.pip_installed)
+
+    def test_brute_force_install_pip_no_installer(self):
+        mgr = PipManager('/usr/bin', pip_installed=False)
+        with patch.object(helpers, 'logged_exec') as mocked_exec:
+            with patch('os.path.exists') as os_exists:
+                with patch.object(mgr, 'download_pip_installer') as download_installer:
+                    os_exists.return_value = False
+                    mgr.brute_force_install_pip()
+
+                    os_exists.assert_called_once_with(mgr.pip_installer_fname)
+                    download_installer.assert_called_once_with()
+            mocked_exec.assert_called_with(['/usr/bin/python', mgr.pip_installer_fname, '-I'])
+        self.assertTrue(mgr.pip_installed)

--- a/tests/test_pipmanager.py
+++ b/tests/test_pipmanager.py
@@ -14,7 +14,7 @@
 #
 # For further info, check  https://github.com/PyAr/fades
 
-""" Tests for pip related code. """
+"""Tests for pip related code."""
 
 import unittest
 from unittest import mock
@@ -28,7 +28,7 @@ from fades import helpers
 
 
 class PipManagerTestCase(unittest.TestCase):
-    """ Check parsing for `pip show`. """
+    """Check parsing for `pip show`."""
 
     def setUp(self):
         logassert.setup(self, 'fades.pipmanager')

--- a/tests/test_pipmanager.py
+++ b/tests/test_pipmanager.py
@@ -20,7 +20,6 @@ import os
 import io
 import tempfile
 import unittest
-from unittest import mock
 from unittest.mock import patch
 
 import logassert

--- a/tests/test_pipmanager.py
+++ b/tests/test_pipmanager.py
@@ -140,10 +140,10 @@ class PipManagerTestCase(unittest.TestCase):
     def test_download_pip_installer(self):
         mgr = PipManager('/usr/bin', pip_installed=False)
         with patch('fades.pipmanager.request.urlopen') as urlopen, \
-                patch('shutil.copy') as copy, \
+                patch('os.rename') as rename, \
                 patch('shutil.copyfileobj') as copyobj:
             mgr.download_pip_installer()
 
         urlopen.assert_called_once_with(pipmanager.PIP_INSTALLER)
         self.assertEqual(copyobj.call_count, 1)
-        copy.assert_has_calls([mock.call(mock.ANY, mgr.pip_installer_fname)])
+        rename.assert_has_calls([mock.call(mgr.pip_installer_fname + '.temp', mgr.pip_installer_fname)])

--- a/tests/test_pipmanager.py
+++ b/tests/test_pipmanager.py
@@ -110,3 +110,14 @@ class PipManagerTestCase(unittest.TestCase):
             logassert.setup(self, 'fades.pipmanager')
             mgr.install('bar')
             self.assertNotLoggedInfo("Hi! This is fades")
+
+    def test_brute_force_install_pip_installer_exists(self):
+        mgr = PipManager('/usr/bin', pip_installed=False)
+        with patch.object(helpers, 'logged_exec') as mocked_exec:
+            with patch('os.path.exists') as os_exists:
+                os_exists.return_value = True
+                mgr.brute_force_install_pip()
+
+                os_exists.assert_called_once_with(mgr.pip_installer_fname)
+            mocked_exec.assert_called_with(['/usr/bin/python', mgr.pip_installer_fname, '-I'])
+        self.assertTrue(mgr.pip_installed)

--- a/tests/test_pipmanager.py
+++ b/tests/test_pipmanager.py
@@ -97,7 +97,7 @@ class PipManagerTestCase(unittest.TestCase):
     def test_install_without_pip(self):
         mgr = PipManager('/usr/bin', pip_installed=False)
         with patch.object(helpers, 'logged_exec') as mocked_exec:
-            with patch.object(mgr, '_brute_force_install_pip') as mocked_install_pip:
+            with patch.object(mgr, 'brute_force_install_pip') as mocked_install_pip:
                 mgr.install('foo')
                 self.assertEqual(mocked_install_pip.call_count, 1)
             mocked_exec.assert_called_with(['/usr/bin/pip', 'install', 'foo'])


### PR DESCRIPTION
In the case pip isn't installed on the current virtualenv, the PipManager downloads a `get-pip.py` script that bootstraps it. If you cancel the download or something goes wrong, the file gets created but might be incomplete. If you retry, you get an error because it asumes it already has the `get-pip.py`.

This pull request makes the file downloading more atomic by first downloading to a temp file and only after complete copying to the definitive file.