### PR TITLE
delete temp folder used for tests

### DIFF
--- a/tests/test_envbuilder.py
+++ b/tests/test_envbuilder.py
@@ -17,6 +17,7 @@
 """Tests for the venv builder module."""
 
 import os
+import shutil
 import tempfile
 import unittest
 from datetime import datetime, timedelta
@@ -278,6 +279,7 @@ class UsageManagerTestCase(unittest.TestCase):
         self.temp_folder = tempfile.mkdtemp()
         self.file_path = os.path.join(self.temp_folder, 'usage_stats')
         self.addCleanup(lambda: os.path.exists(self.tempfile) and os.remove(self.tempfile))
+        self.addCleanup(shutil.rmtree, self.temp_folder, ignore_errors=True)
 
         self.uuids = ['env1', 'env2', 'env3']
 


### PR DESCRIPTION
one tests wasn't deleting tmp files 

```
 /tmp  tree tmp*                                                                                                                                                    5ms 
tmp14aoscfc                                                                                                                                                              
└── usage_stats                                                                                                                                                          
tmp1nx0ux37                                                                                                                               
tmp1sjmitat                                                                                                                       
└── usage_stats                                                                                                                                                          
tmp43bvm3ux                                                                                                                                                              
└── usage_stats                                                                                                                                                          
tmp_87fw02m                                                                                                                                                              
└── usage_stats                                                                                                                                                          
tmpqk3u3p1g                                                                                                                                                              
tmpzz1nqf3n ```