### PR TITLE
not crash if executable is not there. resolve #261

### DIFF
--- a/fades/main.py
+++ b/fades/main.py
@@ -300,7 +300,11 @@ def go():
                 "Calling Python interpreter with arguments %s to execute the child program"
                 " %r with options %s", python_options, args.child_program, args.child_options)
 
-        p = subprocess.Popen(cmd + args.child_options)
+        try:
+            p = subprocess.Popen(cmd + args.child_options)
+        except FileNotFoundError:
+            logger.error("Command not found: %s", args.child_program)
+            sys.exit(1)
 
     def _signal_handler(signum, _):
         """Handle signals received by parent process, send them to child.


### PR DESCRIPTION
It's tested in my local. I was trying to add some tests and I wasn't able to. 

tl;dr:  tests are running in a virtualenv. And fades doesn't support running in a venv. 

I think for the next release we should do some refactor in `go()` splitting it in smaller pieces to allow testing.
Then we can add tests for fades.main

  