### PR TITLE
remove a duplicated log. resolve #263

### DIFF
--- a/fades/cache.py
+++ b/fades/cache.py
@@ -141,7 +141,6 @@ class VEnvsCache:
                 matching_venvs.append((matching, venv))
 
         if not matching_venvs:
-            logger.debug("No matching venv found :(")
             return
 
         return self._select_better_fit(matching_venvs)


### PR DESCRIPTION
```
 ✘  ~/code/fades   master ●  ./bin/fades -v -d aldas                                                                                                          1050ms 
*** fades ***  2018-03-25 13:37:07,837  fades              DEBUG    Running Python sys.version_info(major=3, minor=6, micro=4, releaselevel='final', serial=0) on 'Linux-4.15.12-1-ARCH-x86_64-with-arch'
*** fades ***  2018-03-25 13:37:07,838  fades              DEBUG    Starting fades v. 6.1
*** fades ***  2018-03-25 13:37:07,838  fades              DEBUG    Arguments: Namespace(check_updates=False, child_options=[], child_program=None, clean_unused_venvs=None, dependency=['aldas'], executable=False, ipython=False, no_precheck_availability=False, pip_options=[], python=None, python_options=[], quiet=False, remove=None, requirement=None, system_site_packages=False, verbose=True, version=False, virtualenv_options=[])
*** fades ***  2018-03-25 13:37:07,839  fades.cache        DEBUG    Using cache index: '/home/gilgamezh/.local/share/fades/venvs.idx'
*** fades ***  2018-03-25 13:37:07,839  fades              DEBUG    Dependencies from source file: {}
*** fades ***  2018-03-25 13:37:07,839  fades              DEBUG    Dependencies from docstrings: {}
*** fades ***  2018-03-25 13:37:07,839  fades              DEBUG    Dependencies from requirements file: {}
*** fades ***  2018-03-25 13:37:07,841  fades              DEBUG    Dependencies from parameters: {'pypi': [Requirement.parse('aldas')]}
*** fades ***  2018-03-25 13:37:07,841  fades.helpers      DEBUG    Getting interpreter version for: None
*** fades ***  2018-03-25 13:37:07,841  fades.helpers      DEBUG    Current interpreter is /usr/bin/python3.6
*** fades ***  2018-03-25 13:37:07,842  fades.cache        DEBUG    Searching a venv for: reqs={'pypi': {Requirement.parse('aldas')}} interpreter=/usr/bin/python3.6 options={'pyvenv_options': [], 'virtualenv_options': []}
*** fades ***  2018-03-25 13:37:07,846  fades.cache        DEBUG    No matching venv found :(
*** fades ***  2018-03-25 13:37:07,846  fades              INFO     Checking the availabilty of dependencies in PyPI. You can use '--no-precheck-availability' to avoid it.
*** fades ***  2018-03-25 13:37:07,846  fades.helpers      DEBUG    Checking if Requirement.parse('aldas') exists in PyPI
*** fades ***  2018-03-25 13:37:07,846  fades.helpers      DEBUG    Doing HEAD requests against https://pypi.python.org/pypi/aldas/json
*** fades ***  2018-03-25 13:37:08,231  fades.helpers      ERROR    aldas doesn't exists in PyPI.
*** fades ***  2018-03-25 13:37:08,232  fades              ERROR    An indicated dependency doesn't exists. Exiting

```

And by uuid

```
 ✘  ~/code/fades   better_logging  ./bin/fades -v --rm 1234                                                                                                   4243ms 
*** fades ***  2018-03-25 13:38:33,387  fades              DEBUG    Running Python sys.version_info(major=3, minor=6, micro=4, releaselevel='final', serial=0) on 'Linux-4.15.12-1-ARCH-x86_64-with-arch'
*** fades ***  2018-03-25 13:38:33,388  fades              DEBUG    Starting fades v. 6.1
*** fades ***  2018-03-25 13:38:33,388  fades              DEBUG    Arguments: Namespace(check_updates=False, child_options=[], child_program=None, clean_unused_venvs=None, dependency=None, executable=False, ipython=False, no_precheck_availability=False, pip_options=[], python=None, python_options=[], quiet=False, remove='1234', requirement=None, system_site_packages=False, verbose=True, version=False, virtualenv_options=[])
*** fades ***  2018-03-25 13:38:33,389  fades.cache        DEBUG    Using cache index: '/home/gilgamezh/.local/share/fades/venvs.idx'
*** fades ***  2018-03-25 13:38:33,389  fades.cache        DEBUG    Searching a venv by uuid: 1234
*** fades ***  2018-03-25 13:38:33,389  fades.cache        DEBUG    No matching venv found :(
*** fades ***  2018-03-25 13:38:33,389  fades              WARNING  No virtualenv found with uuid: 1234.

```