### PR TITLE
always use sys.exit(). resolve #280

### DIFF
--- a/fades/helpers.py
+++ b/fades/helpers.py
@@ -135,7 +135,7 @@ def _get_interpreter_info(interpreter=None):
             requested_interpreter_info = logged_exec(args)
         except Exception as error:
             logger.error("Error getting requested interpreter version: %s", error)
-            exit()
+            sys.exit(1)
         requested_interpreter_info = json.loads(requested_interpreter_info[0])
         executable = requested_interpreter_info['path']
         major = requested_interpreter_info['major']

--- a/test
+++ b/test
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2014-2017 Facundo Batista, Nicolás Demarchi
+# Copyright 2014-2018 Facundo Batista, Nicolás Demarchi
 
 set -eu
 
@@ -13,3 +13,6 @@ fi
 FADES='./bin/fades -r requirements.txt'
 
 $FADES -x nosetests --with-xcoverage --cover-package=fades -v -s $TARGET_TESTS
+
+# check if we are using exit() in the code.
+if grep -r -n ' exit(' --include="*.py" .; then echo 'Please use sys.exit() instead of exit(). https://github.com/PyAr/fades/issues/280'; fi


### PR DESCRIPTION
```
 ~/code/fades   better_exit  ack --python 'exit\('                                                                                                             4100ms 
fades/envbuilder.py
87:            sys.exit(1)
90:            sys.exit(2)
93:            sys.exit(3)
149:                sys.exit(4)

fades/main.py
156:        sys.exit(0)
169:        sys.exit(-1)
190:            sys.exit(rc)
265:                sys.exit(1)
326:    sys.exit(rc)

fades/helpers.py
138:            sys.exit(1)
253:            sys.exit(1)

```