### PR TITLE
man/fades.1: Fix typo on synopsis header

### DIFF
--- a/man/fades.1
+++ b/man/fades.1
@@ -3,7 +3,7 @@
 fades - A system that automatically handles the virtualenvs in the cases normally found when writing scripts and simple programs, and even helps to administer big projects.
 
 
-.SH SYNOPSYS
+.SH SYNOPSIS
 .B fades
 [\fB-h\fR][\fB--help\fR]
 [\fB-V\fR][\fB--version\fR]


### PR DESCRIPTION
Fix a typo warned by lintian.

> I: fades: spelling-error-in-manpage usr/share/man/man1/fades.1.gz SYNOPSYS SYNOPSIS