### PR TITLE
Improvements to usage and man. Fixes #304.

### DIFF
--- a/fades/main.py
+++ b/fades/main.py
@@ -51,11 +51,6 @@ The "child options" (everything after the child program) are
 parameters passed as is to the child program.
 """
 
-help_usage = """
-  fades [-h] [-V] [-v] [-q] [-i] [-d DEPENDENCY] [-r REQUIREMENT] [-p PYTHON]
-        [child_program [child_options]]
-"""
-
 
 def consolidate_dependencies(needs_ipython, child_program,
                              requirement_files, manual_dependencies):
@@ -141,7 +136,7 @@ def detect_inside_virtualenv(prefix, real_prefix, base_prefix):
 
 def go():
     """Make the magic happen."""
-    parser = argparse.ArgumentParser(prog='PROG', epilog=help_epilog, usage=help_usage,
+    parser = argparse.ArgumentParser(prog='PROG', epilog=help_epilog,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-V', '--version', action='store_true',
                         help="show version and info about the system, and exit")
@@ -173,7 +168,8 @@ def go():
     parser.add_argument('--check-updates', action='store_true',
                         help=("check for packages updates"))
     parser.add_argument('--no-precheck-availability', action='store_true',
-                        help=("Don't check if the packages exists in PyPI."))
+                        help=("Don't check if the packages exists in PyPI before actually try "
+                              "to install them."))
     parser.add_argument('--pip-options', action='append', default=[],
                         help=("Extra options to be supplied to pip. (this option can be "
                               "used multiple times)"))

--- a/man/fades.1
+++ b/man/fades.1
@@ -22,6 +22,7 @@ fades - A system that automatically handles the virtualenvs in the cases normall
 [\fB--check-updates\fR]
 [\fB--clean-unused-venvs\fR=\fImax_days_to_keep\fR]
 [\fB--get-venv-dir\fR]
+[\fB--no-precheck-availability\fR]
 [child_program [child_options]]
 
 \fBfades\fR can be used to execute directly your script, or put it with a #! at your script's beginning.
@@ -116,6 +117,10 @@ Will remove all virtualenvs that haven't been used for more than MAX_DAYS_TO_KEE
 .TP
 .BR --get-venv-dir
 Show the virtualenv base directory (which includes the virtualenv UUID) and quit.
+
+.TP
+.BR --no-precheck-availability
+Don't check if the packages exists in PyPI before actually try to install them.
 
 
 .SH EXAMPLES


### PR DESCRIPTION
Two things, mainly:

- stopped passing a custom "usage" to ArgumentParser (which was heavily out of date); now we rely in the automatically built "usage", which is identical (but with all the options).

- I double-checked the `man` to see if it was complete, and --no-precheck-availability was missing! Added that (and improved the message also in the arg parsing).