### PR TITLE
#237 WIP: Add -m argument to execute pythons module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -300,6 +300,12 @@ Examples:
 
 ``fades --python-options=-B foo.py``
 
+``fades -m "http.server --bind 0.0.0.0 8090"``
+
+``fades -d tox -m "tox -- -vv"``
+
+``fades -d pygame -m pygame.examples.aliens``
+
 
 Setting options using config files
 ----------------------------------

--- a/fades/main.py
+++ b/fades/main.py
@@ -194,6 +194,7 @@ def go():
                         help=("Indicate that the child_program should be looked up in the "
                               "virtualenv."))
     parser.add_argument('-i', '--ipython', action='store_true', help="use IPython shell.")
+    parser.add_argument('-m', '--module', action='store', help="Run library module as a script")
     parser.add_argument('--system-site-packages', action='store_true', default=False,
                         help=("Give the virtual environment access to the "
                               "system site-packages dir."))
@@ -356,7 +357,13 @@ def go():
 
     # store usage information
     usage_manager.store_usage_stat(venv_data, venvscache)
-    if child_program is None:
+    if args.module:
+        logger.debug(
+            "Executing module %r", args.module)
+        module_option = ["-m"] + args.module.split()
+        cmd = [python_exe] + python_options + module_option
+        p = subprocess.Popen(cmd)
+    elif child_program is None:
         interactive = True
         logger.debug(
             "Calling the interactive Python interpreter with arguments %r", python_options)

--- a/man/fades.1
+++ b/man/fades.1
@@ -13,6 +13,7 @@ fades - A system that automatically handles the virtualenvs in the cases normall
 [\fB-d\fR][\fB--dependency\fR]
 [\fB-r\fR][\fB--requirement\fR]
 [\fB-x\fR][\fB--exec\fR]
+[\fB-m\fR][\fB--module\fR]
 [\fB-p\fR \fIversion\fR][\fB--python\fR=\fIversion\fR]
 [\fB--rm\fR=\fIUUID\fR]
 [\fB--system-site-packages\fR]
@@ -89,6 +90,10 @@ the executable name). It's an error to use this option to execute anything outsi
 directory, just stop using this option for that case.
 
 The \fIchild_program\fR \fBmust\fR be found in the virtualenv's \fIbin\fR directory.
+
+.TP
+.BR -m ", " --module
+Run library module as a script
 
 .TP
 .BR --rm " " \fIUUID\fR


### PR DESCRIPTION
The idea behind this PR is to use the parameter *-m* and *--module* to run modules as script. For example:

```
echo '{"foo": "bar"}' | fades -m json.tool
{
    "foo": "bar"
}

# or

fades -m http.server                      
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...

# or passing parameters

fades -m "http.server -b 127.0.0.1 9000"
Serving HTTP on 127.0.0.1 port 9000 (http://0.0.0.0:9000/) 
```

There is a work around as @gilgamezh said:

```
fades -x python -m http.server
```

So far, the work around has worked for me..but maybe is time to formalize it?

How this shoud be tested?