### PR TITLE
Refactor test_logger with pytest

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -15,34 +15,31 @@
 # For further info, check  https://github.com/PyAr/fades
 
 """Tests for logger related code."""
-
-import unittest
-
-import logassert
-
+import logging
 from fades.logger import set_up as log_set_up
 
 
-class SalutingHandlerTestCase(unittest.TestCase):
+def test_salutes_info(caplog):
     """Check saluting handler."""
+    logger = log_set_up(verbose=False, quiet=True)
+    logger.warning("test foobar")
 
-    def setUp(self):
-        logassert.setup(self, 'fades')
+    assert caplog.record_tuples == [
+        ('fades', logging.INFO, "Hi! This is fades 8.1, automatically managing your dependencies"),
+        ('fades', logging.WARN, 'test foobar')
+    ]
 
-    def test_salutes_info(self):
-        logger = log_set_up(verbose=False, quiet=True)
-        logger.warning("test foobar")
-        self.assertLoggedInfo("Hi! This is fades")
-        self.assertLoggedWarning("test foobar")
 
-    def test_salutes_once(self):
-        logger = log_set_up(verbose=False, quiet=False)
-        logger.info("test foobar")
-        self.assertLoggedInfo("Hi! This is fades")
-        self.assertLoggedInfo("test foobar")
+def test_salutes_once(caplog):
+    logger = log_set_up(verbose=False, quiet=False)
+    logger.info("test foobar")
 
-        # again, check this time it didn't salute, but original log message is ok
-        logassert.setup(self, 'fades')
-        logger.info("test barbarroja")
-        self.assertNotLoggedInfo("Hi! This is fades")
-        self.assertLoggedInfo("test barbarroja")
+    # again, check this time it didn't salute, but original log message is ok
+    caplog.set_level(logging.INFO, logger='fades')
+    logger.info("test barbarroja")
+
+    assert caplog.record_tuples == [
+        ('fades', logging.INFO, "Hi! This is fades 8.1, automatically managing your dependencies"),
+        ('fades', logging.INFO, 'test foobar'),
+        ('fades', logging.INFO, 'test barbarroja'),
+    ]


### PR DESCRIPTION
Hi @facundobatista! I review the logging checks and I think that i found something nice to use with caplog: `caplog.record_tuples` is a list of all the log records.

https://docs.pytest.org/en/latest/logging.html#caplog-fixture

Further it is possible to disable reporting of captured content (stdout, stderr and logs) on failed tests completely with:

`pytest --show-capture=no` or `./testdev -s`