### PR TITLE
Fix use of flake8.get_style_guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ pkg/archlinux/*
 
 # Ides
 .vscode/
+.idea/

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -28,7 +28,7 @@ from pyuca import Collator
 from tests import get_python_filepaths
 
 FLAKE8_ROOTS = ['fades', 'tests']
-FLAKE8_OPTIONS = ['--max-line-length=99', '--select=E,W,F,C,N']
+FLAKE8_OPTIONS = {'max_line_length': 99, 'select': ['E', 'W', 'F', 'C', 'N']}
 PEP257_ROOTS = ['fades']
 
 # avoid seeing all DEBUG logs if the test fails
@@ -39,7 +39,7 @@ for logger_name in ('flake8.plugins', 'flake8.api', 'flake8.checker', 'flake8.ma
 
 def test_flake8_pytest(mocker):
     python_filepaths = get_python_filepaths(FLAKE8_ROOTS)
-    style_guide = get_style_guide(paths=FLAKE8_OPTIONS)
+    style_guide = get_style_guide(**FLAKE8_OPTIONS)
     fake_stdout = io.StringIO()
     mocker.patch('sys.stdout', fake_stdout)
     report = style_guide.check_files(python_filepaths)


### PR DESCRIPTION
I found that `test_flake8_pytest` is using .flake8 file instead of `FLAKE8_OPTIONS`.
To reporduce this error you can delete .flake8 file and run `./test`, this will fail with a lot of ` E501 line too long`. 

With this patch I fixed this behavior.