### PR TITLE
Created --autoimport parameter to autoimport indicated dependencies.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,21 @@ version)::
     import bs4   # fades beautifulsoup4 == 4.2
 
 
+What if no script is given to execute?
+--------------------------------------
+
+If no script or program is passed to execute, *fades* will provide a virtualenv 
+with all the indicated dependencies, and then open an interactive interpreter 
+in the context of that virtualenv.
+
+Here is where it comes very handy the ``-i/--ipython`` option, if that REPL
+is preferred over the standard one.
+
+In the case of using an interactive interpreter, it's also very useful to
+make *fades* to automatically import all the indicated dependencies, 
+passing the ``--autoimport`` parameter.
+
+
 Other ways to specify dependencies
 ----------------------------------
 

--- a/fades/parsing.py
+++ b/fades/parsing.py
@@ -23,7 +23,7 @@ import re
 from pkg_resources import parse_requirements
 
 from fades import REPO_PYPI, REPO_VCS
-from fades.pkgnamesdb import PKG_NAMES_DB
+from fades.pkgnamesdb import MODULE_TO_PACKAGE
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ def _parse_content(fh):
         if import_part.startswith('#'):
             continue
 
-        # get module
+        # Get the module.
         import_tokens = import_part.split()
         if import_tokens[0] == 'import':
             module_path = import_tokens[1]
@@ -140,17 +140,21 @@ def _parse_content(fh):
             logger.debug("Not understood import info: %s", import_tokens)
             continue
         module = module_path.split(".")[0]
-        # If fades know the real name of the pkg. Replace it!
-        if module in PKG_NAMES_DB:
-            module = PKG_NAMES_DB[module]
+
+        # The package has the same name (most of the times! if fades knows the conversion, use it).
+        if module in MODULE_TO_PACKAGE:
+            package = MODULE_TO_PACKAGE[module]
+        else:
+            package = module
+
         # To match the "safe" name that pkg_resources creates:
-        module = module.replace('_', '-')
+        package = package.replace('_', '-')
 
         # get the fades info after 'fades' mark, if any
         if len(fades_part) == 5 or fades_part[5:].strip()[0] in "<>=!":
             # just the 'fades' mark, and maybe a version specification, the requirement is what
             # was imported (maybe with that version comparison)
-            requirement = module + fades_part[5:]
+            requirement = package + fades_part[5:]
         elif fades_part[5] != " ":
             # starts with fades but it's part of a longer weird word
             logger.warning("Not understood fades info: %r", fades_part)

--- a/man/fades.1
+++ b/man/fades.1
@@ -34,7 +34,7 @@ fades - A system that automatically handles the virtualenvs in the cases normall
 
 The first non-option parameter (if any) would be then the child program to execute, and any other parameters after that are passed as is to that child script.
 
-\fBfades\fR can also be executed without passing a child script to execute: in this mode it will open a Python interactive interpreter inside the created/reused virtualenv (taking dependencies from \fI--dependency\fR or \fI--requirement\fR options).
+\fBfades\fR can also be executed without passing a child script to execute: in this mode it will open a Python interactive interpreter inside the created/reused virtualenv (taking dependencies from \fI--dependency\fR or \fI--requirement\fR options). If \fI--autoimport\fR is given, it will automatically import all the installed dependencies.
 
 If the \fIchild_program\fR parameter is really an URL, the script will be automatically downloaded from there (supporting also the most common pastebins URLs: pastebin.com, linkode.org, gist, etc.).
 
@@ -125,6 +125,10 @@ Show the virtualenv base directory (which includes the virtualenv UUID) and quit
 .TP
 .BR --no-precheck-availability
 Don't check if the packages exists in PyPI before actually try to install them.
+
+.TP
+.BR -a ", " --autoimport
+Automatically import the dependencies when in interactive interpreter mode (ignored otherwise).
 
 
 .SH EXAMPLES

--- a/testdev
+++ b/testdev
@@ -10,4 +10,4 @@ else
     TARGET_TESTS=""
 fi
 
-./bin/fades -r requirements.txt -x pytest $TARGET_TESTS
+./bin/fades -r requirements.txt -x pytest -s $TARGET_TESTS

--- a/tests/test_pkgnamesdb.py
+++ b/tests/test_pkgnamesdb.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 Facundo Batista, Nicolás Demarchi
+# Copyright 2020 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -14,19 +14,11 @@
 #
 # For further info, check  https://github.com/PyAr/fades
 
-"""A module to package and viceversa conversion DB.
+"""Tests for the package names DB."""
 
-This is needed for names which don't match with the distrbution's name.
-"""
+from fades import pkgnamesdb
 
-MODULE_TO_PACKAGE = {
-    'bs4': 'beautifulsoup4',
-    'github3': 'github3.py',
-    'uritemplate': 'uritemplate.py',
-    'postgresql': 'py-postgresql',
-    'yaml': 'pyyaml',
-    'PIL': 'pillow',
-    'Crypto': 'pycrypto',
-}
 
-PACKAGE_TO_MODULE = {v: k for k, v in MODULE_TO_PACKAGE.items()}
+def test_db_consistency():
+    """Ensure multiple DB entrypoints are consistent between them."""
+    assert len(pkgnamesdb.MODULE_TO_PACKAGE) == len(pkgnamesdb.PACKAGE_TO_MODULE)


### PR DESCRIPTION
This is done by passing a temp file that does the importing, then leaving the user in the interactive interpreter.

Changing PYTHONPATH was explored, but it was too difficult because a) needing to support *current* PYTHONPATH setting, and b) ipython does not respect that envvar.

Of course, there's no collision for `-i` because the fades is call is *without script at all*, this is enabled only for the interactive interpreter case.

While doing this, I also improved a little the "package names db" and its usage, as I needed the "reverse case" of it.

Also, changed my mind about doing this by default, as I proved more "hacky" than I expected. It's not important, though, if you want to always have it enabled, you can use `--autoimport` in your user's config.
