### PR TITLE
Extended/normalized the --exec parameter behaviour.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,13 +253,6 @@ On the other hand if you pass the ``-q`` or ``--quiet`` parameter, *fades*
 will not show anything (unless it has a real problem), so the original
 script stderr is not polluted at all.
 
-Sometimes, you want to run a script provided by one of the dependencies
-installed into the virtualenv. *fades* supports this via the ``-x`` (
-or ``--exec`` argument). The parameter given to this option needs to be just
-the executable name; it's an error to use this to execute anything outside
-the venv's bin directory, just don't use this option and pass the executable
-directly if you want that.
-
 If you want to use IPython shell you need to call *fades* with ``-i`` or
 ``--ipython`` option. This option will add IPython as a dependency to *fades*
 and it will launch this shell instead of the python one.
@@ -270,6 +263,30 @@ the system libs.
 Finally, no matter how the virtualenv was created, you can always get the
 base directory of the virtualenv in your system using the ``--get-venv-dir``
 option.
+
+
+Running programs in the context of the virtualenv
+-------------------------------------------------
+
+The ``-x/--exec`` parameter allows you to execute any program (not just
+a Python one) in the context of the virtualenv.
+
+By default the mandatory given argument is considered the executable 
+name, relative to the virtualenv's ``bin`` directory, so this is 
+specially useful to execute installed scripts/program by the declared 
+dependencies. E.g.::
+
+    fades -d flake8 -x flake8 my_script_to_be_verified_by_flake8.py
+
+Take in consideration that you can pass an absolute path and it will be 
+respected (but not a relative path, as it will depend of the virtualenv
+location). 
+
+For example, if you want to run a shell script that in turn runs a Python
+program that needs to be executed in the context of the virtualenv, you 
+can do the following::
+
+    fades -r requirements.txt --exec /var/lib/foobar/special.sh
 
 
 How to deal with packages that are upgraded in PyPI

--- a/fades/main.py
+++ b/fades/main.py
@@ -161,9 +161,9 @@ def decide_child_program(args_executable, args_child_program):
     logger = logging.getLogger('fades')
 
     if args_executable:
-        # if --exec given, check that it's just the executable name,
-        # not absolute or relative paths
-        if os.path.sep in args_child_program:
+        # If --exec given, check that it's just the executable name or an absolute path;
+        # relative paths are forbidden (as the location of the venv should not be known).
+        if os.path.sep in args_child_program and args_child_program[0] != os.path.sep:
             logger.error(
                 "The parameter to --exec must be a file name (to be found "
                 "inside venv's bin directory), not a file path: %r",
@@ -231,7 +231,7 @@ def _get_normalized_args(parser):
 
 def go():
     """Make the magic happen."""
-    parser = argparse.ArgumentParser(prog='PROG', epilog=HELP_EPILOG,
+    parser = argparse.ArgumentParser(prog='fades', epilog=HELP_EPILOG,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-V', '--version', action='store_true',
                         help="show version and info about the system, and exit")
@@ -251,8 +251,9 @@ def go():
                         help=("Specify the Python interpreter to use.\n"
                               " Default is: %s") % (sys.executable,))
     parser.add_argument('-x', '--exec', dest='executable', action='store_true',
-                        help=("Indicate that the child_program should be looked up in the "
-                              "virtualenv."))
+                        help=(
+                            "Execute the child_program (must be present) in the context "
+                            "of the virtualenv."))
     parser.add_argument('-i', '--ipython', action='store_true', help="use IPython shell.")
     parser.add_argument('--system-site-packages', action='store_true', default=False,
                         help=("Give the virtual environment access to the "
@@ -300,6 +301,15 @@ def go():
         print("    Python:", sys.version_info)
         print("    System:", platform.platform())
         return 0
+
+    # The --exec flag needs child_program to exist (this is not handled at
+    # argparse level because it's easier to collect the executable as the
+    # normal child_program, so everything after that are parameteres
+    # considered for the executable itself, not for fades)
+    if args.executable and not args.child_program:
+        parser.print_usage()
+        print("fades: error: argument -x/--exec needs child_program to be present")
+        return 2
 
     # set up logger and dump basic version info
     logger = fades_logger.set_up(args.verbose, args.quiet)
@@ -434,7 +444,11 @@ def go():
     else:
         interactive = False
         if args.executable:
-            cmd = [os.path.join(venv_data['env_bin_path'], child_program)]
+            # Build the exec path relative to 'bin' dir; note that if child_program's path
+            # is absolute (starting with '/') the resulting exec_path will be just it,
+            # which is something fades supports
+            exec_path = os.path.join(venv_data['env_bin_path'], child_program)
+            cmd = [exec_path]
             logger.debug("Calling child program %r with options %s",
                          child_program, args.child_options)
         else:

--- a/man/fades.1
+++ b/man/fades.1
@@ -23,6 +23,7 @@ fades - A system that automatically handles the virtualenvs in the cases normall
 [\fB--clean-unused-venvs\fR=\fImax_days_to_keep\fR]
 [\fB--get-venv-dir\fR]
 [\fB--no-precheck-availability\fR]
+[\fB-a\fR][\fB--autoimport\fR]
 [child_program [child_options]]
 
 \fBfades\fR can be used to execute directly your script, or put it with a #! at your script's beginning.
@@ -84,11 +85,7 @@ The dependencies can be indicated in multiple places (in the Python source file,
 
 .TP
 .BR -x ", " --exec
-Execute the \fIchild_program\fR inside the virtualenv (so the parameter given needs to be just 
-the executable name). It's an error to use this option to execute anything outside the venv's bin 
-directory, just stop using this option for that case.
-
-The \fIchild_program\fR \fBmust\fR be found in the virtualenv's \fIbin\fR directory.
+Execute the \fIchild_program\fR in the context of the virtualenv. The child_program, which in this case becomes a mandatory parameter, can be just the executable name (relative to the venv's bin directory) or an absolute path.
 
 .TP
 .BR --rm " " \fIUUID\fR

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -213,10 +213,16 @@ class ChildProgramDeciderTestCase(unittest.TestCase):
         self.assertEqual(analyzable, "new_path_script")
         self.assertEqual(child, "new_path_script")
 
-    def test_indicated_with_executable_flag_in_path(self):
-        """Absolute paths not allowed when using --exec."""
+    def test_indicated_with_executable_flag_with_relative_path(self):
+        """Relative paths not allowed when using --exec."""
         with self.assertRaises(FadesError):
-            main.decide_child_program(True, os.path.join("path", "foobar.py"))
+            main.decide_child_program(True, os.path.join("path", "../foobar.py"))
+
+    def test_indicated_with_executable_flag_with_absolute_path(self):
+        """Absolute paths are allowed when using --exec."""
+        analyzable, child = main.decide_child_program(True, "/tmp/foo/bar.py")
+        self.assertIsNone(analyzable)
+        self.assertEqual(child, "/tmp/foo/bar.py")
 
 
 # ---------------------------------------


### PR DESCRIPTION
This has several details:

- Improve docs: man, argument help and specially README, where I separated
  it's explanation to a different section.

- Allow an absolute path to be given beyond a simple name (but
  not relative paths!).

- Made it mandatory to include a child_program if --exec is used.

Also, two small fixes: fixed program name in argparse, and included a
forgotten --autoimport reference in the man.