### PR TITLE
Added support for native -m/--module.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -288,6 +288,12 @@ can do the following::
 
     fades -r requirements.txt --exec /var/lib/foobar/special.sh
 
+Finally, if the intended code to run is prepared to be executed as a module 
+(what you would normally run as `python3 -m some_module`), you can 
+use the same parameter with *fades* to run that module inside the virtualenv::
+
+    fades -r requirements.txt -m some_module
+
 
 How to deal with packages that are upgraded in PyPI
 ---------------------------------------------------
@@ -483,9 +489,9 @@ Download the script from the given pastebin and executes it (previously building
 
     fades http://linkode.org/#4QI4TrPlGf1gK2V7jPBC47
 
-Run all the tests in a project and at the same time freeze dependencies for later deployment::
+Run all the tests in a project (running ``pytest`` directly as a module, for better behaviour) and at the same time freeze dependencies for later deployment::
 
-    fades -r requirements.txt --freeze -x pytest -v
+    fades -r requirements.txt --freeze -m pytest -v
 
 
 Some examples using fades in project scripts

--- a/man/fades.1
+++ b/man/fades.1
@@ -25,6 +25,7 @@ fades - A system that automatically handles the virtualenvs in the cases normall
 [\fB--no-precheck-availability\fR]
 [\fB-a\fR][\fB--autoimport\fR]
 [\fB--freeze\fR]
+[\fB-m\fR][\fB--module\fR]
 [child_program [child_options]]
 
 \fBfades\fR can be used to execute directly your script, or put it with a #! at your script's beginning.
@@ -131,6 +132,10 @@ Automatically import the dependencies when in interactive interpreter mode (igno
 .TP
 .BR --freeze " " \fIFILEPATH\fR
 Will operate exactly as without the command, but also it will dump the revisions of installed dependencies to the given \fBfilepath\fR.
+
+.TP
+.BR -m ", " --module
+Run library module as a script (same behaviour than Python's \fB-m\fR parameter).
 
 
 .SH EXAMPLES


### PR DESCRIPTION
Made it mutually exclusive with -x/--exec.

Also improve the name of the variable of the process, and refactored what is logged when executing a script/module: it's now more explicit, I tried it and provides more information yet being more simple.