### PR TITLE
Don't do any special for shebang parameters as they come normally.

### DIFF
--- a/fades/main.py
+++ b/fades/main.py
@@ -23,7 +23,6 @@ import os
 import platform
 import signal
 import sys
-import shlex
 import subprocess
 import tempfile
 
@@ -215,21 +214,6 @@ def detect_inside_virtualenv(prefix, real_prefix, base_prefix):
     return prefix != base_prefix
 
 
-def _get_normalized_args(parser):
-    """Return the parsed command line arguments.
-
-    Support the case when executed from a shebang, where all the
-    parameters come in sys.argv[1] in a single string separated
-    by spaces (in this case, the third parameter is what is being
-    executed)
-    """
-    env = os.environ
-    if '_' in env and env['_'] != sys.argv[0] and len(sys.argv) >= 1 and " " in sys.argv[1]:
-        return parser.parse_args(shlex.split(sys.argv[1]) + sys.argv[2:])
-    else:
-        return parser.parse_args()
-
-
 def go():
     """Make the magic happen."""
     parser = argparse.ArgumentParser(prog='fades', epilog=HELP_EPILOG,
@@ -294,7 +278,7 @@ def go():
     parser.add_argument('child_program', nargs='?', default=None)
     parser.add_argument('child_options', nargs=argparse.REMAINDER)
 
-    cli_args = _get_normalized_args(parser)
+    cli_args = parser.parse_args()
 
     # update args from config file (if needed).
     args = file_options.options_from_file(cli_args)


### PR DESCRIPTION
This fixes the situation where a file (where fades is used in the shebang) name has spaces.