### PR TITLE
Fixed Windows Issue

### DIFF
--- a/fades/pipmanager.py
+++ b/fades/pipmanager.py
@@ -58,7 +58,8 @@ class PipManager():
         # Always update pip to get latest behaviours (specially regarding security); this has
         # the nice side effect of getting logged the pip version that is used.
         if not self.avoid_pip_upgrade:
-            helpers.logged_exec([self.pip_exe, 'install', 'pip', '--upgrade'])
+            python_exe = os.path.join(self.env_bin_path, "python")
+            helpers.logged_exec([python_exe, '-m', 'pip', 'install', 'pip', '--upgrade'])
 
         # split to pass several tokens on multiword dependency (this is very specific for '-e' on
         # external requirements, but implemented generically; note that this does not apply for

--- a/tests/test_pipmanager.py
+++ b/tests/test_pipmanager.py
@@ -78,7 +78,8 @@ def test_install(mocker):
     mgr.install("foo")
 
     # check it always upgrades pip, and then the proper install
-    c1 = mocker.call([pip_path, "install", "pip", "--upgrade"])
+    python_path = os.path.join(BIN_PATH, "python")
+    c1 = mocker.call([python_path, "-m", "pip", "install", "pip", "--upgrade"])
     c2 = mocker.call([pip_path, "install", "foo"])
     assert mock.call_args_list == [c1, c2]
 


### PR DESCRIPTION
Windows can't use pip.exe and delete it while it is using it.
Just follow the indication given and use python -m pip install pip --upgrade instead.