### PR TITLE
cli synonyms for --get-venv-dir and --check-updates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Martin Alderete <malderete@gmail.com>
 matuu <matu.varela@gmail.com>
 Nicolás Demarchi <mail@gilgamezh.me>
 Ricardo Kirkner <ricardo@kirkner.com.ar>
+Rushil Patel <rushil.patel20@imperial.ac.uk>

--- a/README.rst
+++ b/README.rst
@@ -261,8 +261,8 @@ You can also use ``--system-site-packages`` to create a venv with access to
 the system libs.
 
 Finally, no matter how the virtualenv was created, you can always get the
-base directory of the virtualenv in your system using the ``--get-venv-dir``
-option.
+base directory of the virtualenv in your system using the ``--where`` (or its
+alias ``--get-venv-dir``) option.
 
 
 Running programs in the context of the virtualenv
@@ -312,7 +312,10 @@ You can tell fades to do otherwise, just do::
     fades -d foobar --check-updates
 
 ...and *fades* will search updates for the package on PyPI, and as it will
-found version 8, will create a new virtualenv using the latest version.
+found version 8, will create a new virtualenv using the latest version. You
+can also use the ``-U`` option as an alias for ``--check-updates``::
+    
+    fades -d foobar -U
 
 From this moment on, if you request ``fades -d foobar`` it will bring the
 virtualenv with the new version. If you want to get a virtualenv with
@@ -435,7 +438,7 @@ unnecessary virtual environments from disk.
 By running *fades* with the ``--rm`` argument, *fades* will remove the
 virtualenv matching the provided UUID if such a virtualenv exists (one easy
 way to find out the virtualenv's UUID is calling *fades* with the
-``--get-venv-dir`` option.
+``--where`` option).
 
 Another way to clean up the cache is to remove all venvs that haven't been used for some time.
 In order to do this you need to call *fades* with ``--clean-unused-venvs``.

--- a/fades/main.py
+++ b/fades/main.py
@@ -260,13 +260,13 @@ def go():
         help="extra options to be supplied to python (this option can be used multiple times)")
     parser.add_argument(
         '--rm', dest='remove', metavar='UUID',
-        help="remove a virtualenv by UUID; see --get-venv-dir option to easily find out the UUID")
+        help="remove a virtualenv by UUID; see --where option to easily find out the UUID")
     parser.add_argument(
         '--clean-unused-venvs', action='store',
         help="remove venvs that haven't been used for more than the indicated days and compact "
              "usage stats file (all this takes place at the beginning of the execution)")
     parser.add_argument(
-        '--get-venv-dir', '--where', action='store_true',
+        '--where', '--get-venv-dir', action='store_true',
         help="show the virtualenv base directory (including the venv's UUID) and quit")
     parser.add_argument(
         '-a', '--autoimport', action='store_true',
@@ -429,7 +429,7 @@ def go():
         # store this new venv in the cache
         venvscache.store(installed, venv_data, interpreter, options)
 
-    if args.get_venv_dir:
+    if args.where:
         # all it was requested is the virtualenv's path, show it and quit (don't run anything)
         print(venv_data['env_path'])
         return 0

--- a/fades/main.py
+++ b/fades/main.py
@@ -266,7 +266,7 @@ def go():
         help="remove venvs that haven't been used for more than the indicated days and compact "
              "usage stats file (all this takes place at the beginning of the execution)")
     parser.add_argument(
-        '--get-venv-dir', action='store_true',
+        '--get-venv-dir', '--where', action='store_true',
         help="show the virtualenv base directory (including the venv's UUID) and quit")
     parser.add_argument(
         '-a', '--autoimport', action='store_true',

--- a/fades/main.py
+++ b/fades/main.py
@@ -248,7 +248,7 @@ def go():
         '--virtualenv-options', action='append', default=[],
         help="extra options to be supplied to virtualenv (this option can be used multiple times)")
     parser.add_argument(
-        '--check-updates', action='store_true', help="check for packages updates")
+        '-U', '--check-updates', action='store_true', help="check for packages updates")
     parser.add_argument(
         '--no-precheck-availability', action='store_true',
         help="don't check if the packages exists in PyPI before actually try to install them")

--- a/man/fades.1
+++ b/man/fades.1
@@ -19,7 +19,7 @@ fades - A system that automatically handles the virtualenvs in the cases normall
 [\fB--virtualenv-options\fR=\fIoptions\fR]
 [\fB--pip-options\fR=\fIoptions\fR]
 [\fB--python-options\fR=\fIoptions\fR]
-[\fB--check-updates\fR]
+[\fB-U\fR][\fB--check-updates\fR]
 [\fB--clean-unused-venvs\fR=\fImax_days_to_keep\fR]
 [\fB--get-venv-dir\fR]
 [\fB--no-precheck-availability\fR]
@@ -111,7 +111,7 @@ Extra options to be supplied to pip. (this option can be used multiple times)
 Extra options to be supplied to python. (this option can be used multiple times)
 
 .TP 
-.BR --check-updates
+.BR -U ", " --check-updates
 Will check for updates in PyPI to verify if there are new versions for the requested dependencies. If a new version is available for a dependency, it will use it (if the dependency was requested without version) or just inform which new version is available (if the dependency was requested with a specific version).
 
 .TP

--- a/man/fades.1
+++ b/man/fades.1
@@ -21,7 +21,7 @@ fades - A system that automatically handles the virtualenvs in the cases normall
 [\fB--python-options\fR=\fIoptions\fR]
 [\fB-U\fR][\fB--check-updates\fR]
 [\fB--clean-unused-venvs\fR=\fImax_days_to_keep\fR]
-[\fB--get-venv-dir\fR]
+[\fB--where\fR][\fB--get-venv-dir\fR]
 [\fB--no-precheck-availability\fR]
 [\fB-a\fR][\fB--autoimport\fR]
 [\fB--freeze\fR]
@@ -119,7 +119,7 @@ Will check for updates in PyPI to verify if there are new versions for the reque
 Will remove all virtualenvs that haven't been used for more than MAX_DAYS_TO_KEEP days.
 
 .TP
-.BR --get-venv-dir
+.BR --where ", " --get-venv-dir
 Show the virtualenv base directory (which includes the virtualenv UUID) and quit.
 
 .TP


### PR DESCRIPTION
A quick change to address the following issues:

- #418  : added `-U` as a synonym for `--check-updates` and updated `man` page
- #409 : added `--where` as a synonym for `--get-venv-dir` and updated `man` page