### PR TITLE
Stop using the term virtualenv

### DIFF
--- a/.github/workflows/integtests.yaml
+++ b/.github/workflows/integtests.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          pacman -Sy --noconfirm python3.11 python-setuptools
+          pacman -Sy --noconfirm python311 python-setuptools
       - name: Simple fades run
         run: |
           cd /fades

--- a/.github/workflows/integtests.yaml
+++ b/.github/workflows/integtests.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          pacman -Sy --noconfirm python311 python-setuptools
+          pacman -Sy --noconfirm python3 python-setuptools
       - name: Simple fades run
         run: |
           cd /fades

--- a/.github/workflows/integtests.yaml
+++ b/.github/workflows/integtests.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          pacman -Sy --noconfirm python3 python-setuptools
+          pacman -Sy --noconfirm python3.11 python-setuptools
       - name: Simple fades run
         run: |
           cd /fades

--- a/README.rst
+++ b/README.rst
@@ -19,15 +19,15 @@ What is fades?
     :alt: Appveyor Status
 
 
-fades is a system that automatically handles the virtualenvs in the
+fades is a system that automatically handles the virtual environments in the
 cases normally found when writing scripts and simple programs, and
 even helps to administer big projects.
 
 .. image:: resources/logo256.png
 
-*fades* will automagically create a new virtualenv (or reuse a previous
+*fades* will automagically create a new virtual environment (or reuse a previous
 created one), installing the necessary dependencies, and execute
-your script inside that virtualenv, with the only requirement
+your script inside that virtual environment, with the only requirement
 of executing the script with *fades* and also marking the required
 dependencies.
 
@@ -41,7 +41,7 @@ child script.
 
 *fades* can also be executed without passing a child script to execute:
 in this mode it will open a Python interactive interpreter inside the
-created/reused virtualenv (taking dependencies from ``--dependency`` or
+created/reused virtual environment (taking dependencies from ``--dependency`` or
 ``--requirement`` options).
 
 .. contents::
@@ -71,7 +71,7 @@ When you write an script, you have to take two special measures:
 - need to mark those dependencies
 
 At the moment you execute the script, fades will search a
-virtualenv with the marked dependencies, if it doesn't exists
+virtual environment with the marked dependencies, if it doesn't exists
 fades will create it, and execute the script in that environment.
 
 
@@ -119,7 +119,7 @@ The simplest comment is like::
 The ``fades`` is mandatory, in this examples the repository is PyPI,
 see `About different repositories`_ below for other examples.
 
-With that comment, *fades* will install automatically in the virtualenv the
+With that comment, *fades* will install automatically in the virtual environment the
 ``somemodule`` or ``somepackage`` from PyPI.
 
 Also, you can indicate a particular version condition, examples::
@@ -139,9 +139,9 @@ version)::
 What if no script is given to execute?
 --------------------------------------
 
-If no script or program is passed to execute, *fades* will provide a virtualenv 
+If no script or program is passed to execute, *fades* will provide a virtual environment 
 with all the indicated dependencies, and then open an interactive interpreter 
-in the context of that virtualenv.
+in the context of that virtual environment.
 
 Here is where it comes very handy the ``-i/--ipython`` option, if that REPL
 is preferred over the standard one.
@@ -155,7 +155,7 @@ Other ways to specify dependencies
 ----------------------------------
 
 Apart of marking the imports in the source file, there are other ways
-to tell *fades* which dependencies to install in the virtualenv.
+to tell *fades* which dependencies to install in the virtual environment.
 
 One way is through command line, passing the ``--dependency`` parameter.
 This option can be specified multiple times (once per dependency), and
@@ -202,7 +202,7 @@ If you prefer, you can be explicit about which kind of repository *fades* should
     -d pypi::requests
     -d vcs::git+https://github.com/kennethreitz/requests.git#egg=requests
 
-There are two basic repositories: ``pypi`` which will make *fades* to install the desired dependency from PyPI, and ``vcs``, which will make *fades* to treat the dependency as a URL for a version control system site. In the first case, for PyPI, a full range of version comparators can be specified, as usual. For ``vcs`` repositories, though, the comparison is always exact: if the very same dependency is specified, a *virtualenv* is reused, otherwise a new one will be created and populated.
+There are two basic repositories: ``pypi`` which will make *fades* to install the desired dependency from PyPI, and ``vcs``, which will make *fades* to treat the dependency as a URL for a version control system site. In the first case, for PyPI, a full range of version comparators can be specified, as usual. For ``vcs`` repositories, though, the comparison is always exact: if the very same dependency is specified, a *virtual environment* is reused, otherwise a new one will be created and populated.
 
 In both cases (specifying the repository explicitly or implicitly) there is no difference if the dependency is specified in the command line, in a ``requirements.txt`` file, in the script's docstring, etc.  In the case of marking the ``import`` directly in the script, it slightly different.
 
@@ -228,13 +228,13 @@ because we're mixing the protocol indication with the path)::
     fades -d file:///home/crazyuser/myproject/allstars/
 
 
-How to control the virtualenv creation and usage?
--------------------------------------------------
+How to control the virtual environment creation and usage?
+----------------------------------------------------------
 
-You can influence several details of all the virtualenv related process.
+You can influence several details of all the virtual environment related process.
 
 The most important detail is which version of Python will be used in
-the virtualenv. Of course, the corresponding version of Python needs to
+the virtual environment. Of course, the corresponding version of Python needs to
 be installed in your system, but you can control exactly which one to use.
 
 No matter which way you're executing the script (see above), you can
@@ -243,7 +243,7 @@ be used just with the number (``3.9``), the whole name (``python3.9``) or
 the whole path (``/usr/bin/python3.9``).
 
 Other detail is the verbosity of *fades* when telling what is doing. By
-default, *fades* only will use stderr to tell if a virtualenv is being
+default, *fades* only will use stderr to tell if a virtual environment is being
 created, and to let the user know that is doing an operation that
 requires an active network connection (e.g. installing a new dependency).
 
@@ -260,37 +260,37 @@ and it will launch this shell instead of the python one.
 You can also use ``--system-site-packages`` to create a venv with access to
 the system libs.
 
-Finally, no matter how the virtualenv was created, you can always get the
-base directory of the virtualenv in your system using the ``--where`` (or its
+Finally, no matter how the virtual environment was created, you can always get the
+base directory of the virtual environment in your system using the ``--where`` (or its
 alias ``--get-venv-dir``) option.
 
 
-Running programs in the context of the virtualenv
--------------------------------------------------
+Running programs in the context of the virtual environment
+----------------------------------------------------------
 
 The ``-x/--exec`` parameter allows you to execute any program (not just
-a Python one) in the context of the virtualenv.
+a Python one) in the context of the virtual environment.
 
 By default the mandatory given argument is considered the executable 
-name, relative to the virtualenv's ``bin`` directory, so this is 
+name, relative to the environment's ``bin`` directory, so this is 
 specially useful to execute installed scripts/program by the declared 
 dependencies. E.g.::
 
     fades -d flake8 -x flake8 my_script_to_be_verified_by_flake8.py
 
 Take in consideration that you can pass an absolute path and it will be 
-respected (but not a relative path, as it will depend of the virtualenv
+respected (but not a relative path, as it will depend of the virtual environment
 location). 
 
 For example, if you want to run a shell script that in turn runs a Python
-program that needs to be executed in the context of the virtualenv, you 
+program that needs to be executed in the context of the virtual environment, you 
 can do the following::
 
     fades -r requirements.txt --exec /var/lib/foobar/special.sh
 
 Finally, if the intended code to run is prepared to be executed as a module 
 (what you would normally run as `python3 -m some_module`), you can 
-use the same parameter with *fades* to run that module inside the virtualenv::
+use the same parameter with *fades* to run that module inside the virtual environment::
 
     fades -r requirements.txt -m some_module
 
@@ -298,27 +298,27 @@ use the same parameter with *fades* to run that module inside the virtualenv::
 How to deal with packages that are upgraded in PyPI
 ---------------------------------------------------
 
-When you tell *fades* to create a virtualenv using one dependency and
+When you tell *fades* to create a virtual environment using one dependency and
 don't specify a version, it will install the latest one from PyPI.
 
 For example, you do ``fades -d foobar`` and it installs foobar in
 version 7. At some point, there is a new version of foobar in PyPI,
 version 8, but if do ``fades -d foobar`` it will just reuse previously
-created virtualenv, with version 7, not downloading the new version and
-creating a new virtualenv with it!
+created virtual environment, with version 7, not downloading the new version and
+creating a new virtual environment with it!
 
 You can tell fades to do otherwise, just do::
 
     fades -d foobar --check-updates
 
 ...and *fades* will search updates for the package on PyPI, and as it will
-found version 8, will create a new virtualenv using the latest version. You
+found version 8, will create a new virtual environment using the latest version. You
 can also use the ``-U`` option as an alias for ``--check-updates``::
     
     fades -d foobar -U
 
 From this moment on, if you request ``fades -d foobar`` it will bring the
-virtualenv with the new version. If you want to get a virtualenv with
+virtual environment with the new version. If you want to get a virtual environment with
 not-the-latest version for any dependency, just specify the proper versions.
 
 You can even use the ``--check-updates`` parameter when specifying the package
@@ -335,7 +335,7 @@ What about pinning dependencies?
 --------------------------------
 
 One nice benefit of *fades* is that every time dependencies change in your 
-project, you actually get to use a new virtualenv automatically.
+project, you actually get to use a new virtual environment automatically.
 
 If you don't pin the dependencies in your requirements file, this has 
 another nice side effect: everytime you use them in a new environment (or
@@ -423,28 +423,29 @@ There is a little difference in how fades handle these settings: "dependency", "
 "virtualenv-options". In these cases you have to use a semicolon separated list.
 
 The most important thing is that these options will be merged. So if you configure in
-`/etc/fades/fades.ini` "dependency=requests" you will have requests in all the virtualenvs
+`/etc/fades/fades.ini` "dependency=requests" you will have requests in all the virtual environments
 created by fades.
 
 
-How to clean up old virtualenvs?
---------------------------------
+How to clean up old virtual environments?
+-----------------------------------------
 
 When using *fades* virtual environments are something you should not have to think about.
-*fades* will do the right thing and create a new virtualenv that matches the required
+*fades* will do the right thing and create a new virtual environment that matches the required
 dependencies. There are cases however when you'll want to do some clean up to remove
 unnecessary virtual environments from disk.
 
 By running *fades* with the ``--rm`` argument, *fades* will remove the
-virtualenv matching the provided UUID if such a virtualenv exists (one easy
-way to find out the virtualenv's UUID is calling *fades* with the
+virtual environment matching the provided UUID if such a environment exists (one easy
+way to find out the environment's UUID is calling *fades* with the
 ``--where`` option).
 
 Another way to clean up the cache is to remove all venvs that haven't been used for some time.
 In order to do this you need to call *fades* with ``--clean-unused-venvs``.
 When fades it's called with this option, it runs in mantain mode, this means that fades will exit
 after finished this task.
-All virtualenvs that haven't been used for more days than the value indicated in param will be
+
+All virtual environments that haven't been used for more days than the value indicated in param will be
 removed.
 
 It is recommended to have some automatically way of run this option;
@@ -456,7 +457,7 @@ ie, add a cron task that perform this command::
 Some command line examples
 --------------------------
 
-Execute ``foo.py`` under *fades*, passing the ``--bar`` parameter to the child program, in a virtualenv with the dependencies indicated in the source code::
+Execute ``foo.py`` under *fades*, passing the ``--bar`` parameter to the child program, in a virtual environment with the dependencies indicated in the source code::
 
     fades foo.py --bar
 
@@ -464,19 +465,19 @@ Execute ``foo.py`` under *fades*, showing all the *fades* messages (verbose mode
 
     fades -v foo.py
 
-Execute ``foo.py`` under *fades* (passing the ``--bar`` parameter to it), in a virtualenv with the dependencies indicated in the source code and also ``dependency1`` and ``dependency2`` (any version > 3.2)::
+Execute ``foo.py`` under *fades* (passing the ``--bar`` parameter to it), in a virtual environment with the dependencies indicated in the source code and also ``dependency1`` and ``dependency2`` (any version > 3.2)::
 
     fades -d dependency1 -d "dependency2>3.2" foo.py --bar
 
-Execute the Python interactive interpreter in a virtualenv with ``dependency1`` installed::
+Execute the Python interactive interpreter in a virtual environment with ``dependency1`` installed::
 
     fades -d dependency1
 
-Execute the Python interactive interpreter in a virtualenv after installing there all dependencies taken from the ``requirements.txt`` file::
+Execute the Python interactive interpreter in a virtual environment after installing there all dependencies taken from the ``requirements.txt`` file::
 
     fades -r requirements.txt
 
-Execute the Python interactive interpreter in a virtualenv after installing there all dependencies taken from files ``requirements.txt`` and ``requirements_devel.txt``::
+Execute the Python interactive interpreter in a virtual environment after installing there all dependencies taken from files ``requirements.txt`` and ``requirements_devel.txt``::
 
     fades -r requirements.txt -r requirements_devel.txt
 
@@ -484,11 +485,11 @@ Use the ``django-admin.py`` script to start a new project named ``foo``, without
 
     fades -d django -x django-admin.py startproject foo
 
-Remove a virtualenv matching the given uuid from disk and cache index::
+Remove a virtual environment matching the given uuid from disk and cache index::
 
     fades --rm 89a2bf83-c280-4918-a78d-c35506efd69d
 
-Download the script from the given pastebin and executes it (previously building a virtualenv for the dependencies indicated in that pastebin, of course)::
+Download the script from the given pastebin and executes it (previously building a virtual environment for the dependencies indicated in that pastebin, of course)::
 
     fades http://linkode.org/#4QI4TrPlGf1gK2V7jPBC47
 
@@ -501,9 +502,9 @@ Some examples using fades in project scripts
 --------------------------------------------
 
 Including *fades* in project helper scripts makes it easy to stop 
-worrying about the virtualenv activation/deactivation when working 
+worrying about the virtual environment activation/deactivation when working 
 in that project, and also solves the problem of needing to 
-update/change/fix an already created virtualenv if the 
+update/change/fix an already created virtual environment if the 
 dependencies change.
 
 This is an example of how a script to run your project may look like::
@@ -515,7 +516,7 @@ This is an example of how a script to run your project may look like::
         fades -r requirements.txt bin/start
     else
         echo 2
-        # hope you are in the correct virtualenv
+        # hope you are in the correct virtual environment
         python3 bin/start
     fi
 
@@ -529,11 +530,11 @@ of the development dependencies::
 What if Python is updated in my system?
 ---------------------------------------
 
-The virtualenvs created by fades depend on the Python version used to
+The virtual environments created by fades depend on the Python version used to
 create them, considering its major and minor version.
 
 This means that if run fades with a Python version and then run it again
-with a different Python version, it may need to create a new virtualenv.
+with a different Python version, it may need to create a new virtual environment.
 
 Let's see some examples. Let's say you run fades with ``python``, which
 is a symlink in your ``/usr/bin/`` to ``python3.4`` (running it directly
@@ -548,7 +549,7 @@ is pointed to this new one, fades will start creating all the
 virtualenvs again, with this new version.
 
 This is a good thing, because you want that the dependencies installed
-with one specific Python in the virtualenv are kept being used by the
+with one specific Python in the virtual environment are kept being used by the
 same Python version.
 
 However, if you want to avoid this behaviour, be sure to always call fades

--- a/fades/envbuilder.py
+++ b/fades/envbuilder.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 Facundo Batista, Nicolás Demarchi
+# Copyright 2014-2024 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 class _FadesEnvBuilder(EnvBuilder):
-    """Create always a virtualenv.
+    """Create always a virtual environment.
 
     This is structured as a class mostly to take advantage of EnvBuilder, not because
     it's provides the best interface: external callers should just use module's ``create_env``
@@ -80,7 +80,7 @@ class _FadesEnvBuilder(EnvBuilder):
             super().__init__(symlinks=True)
 
     def create_with_virtualenv(self, interpreter, virtualenv_options):
-        """Create a virtualenv using the virtualenv lib."""
+        """Create a virtual environment using the virtualenv lib."""
         args = ['virtualenv', '--python', interpreter, self.env_path]
         args.extend(virtualenv_options)
         if not self.pip_installed:
@@ -100,17 +100,17 @@ class _FadesEnvBuilder(EnvBuilder):
             raise FadesError('General error while running virtualenv')
 
     def create_env(self, interpreter, is_current, options):
-        """Create the virtualenv and return its info."""
+        """Create the virtual environment and return its info."""
         if is_current:
             # apply pyvenv options
             pyvenv_options = options['pyvenv_options']
             if "--system-site-packages" in pyvenv_options:
                 self.system_site_packages = True
-            logger.debug("Creating virtualenv with pyvenv. options=%s", pyvenv_options)
+            logger.debug("Creating virtual environment with pyvenv. options=%s", pyvenv_options)
             self.create(self.env_path)
         else:
             virtualenv_options = options['virtualenv_options']
-            logger.debug("Creating virtualenv with virtualenv")
+            logger.debug("Creating virtual environment with virtualenv")
             self.create_with_virtualenv(interpreter, virtualenv_options)
         logger.debug("env_bin_path: %s", self.env_bin_path)
 
@@ -130,7 +130,7 @@ class _FadesEnvBuilder(EnvBuilder):
 
 def create_venv(requested_deps, interpreter, is_current, options, pip_options, avoid_pip_upgrade):
     """Create a new virtualvenv with the requirements of this script."""
-    # create virtualenv
+    # create virtual environment
     env = _FadesEnvBuilder()
     env_path, env_bin_path, pip_installed = env.create_env(interpreter, is_current, options)
     venv_data = {}
@@ -156,7 +156,7 @@ def create_venv(requested_deps, interpreter, is_current, options, pip_options, a
             try:
                 mgr.install(dependency)
             except Exception:
-                logger.debug("Installation Step failed, removing virtualenv")
+                logger.debug("Installation Step failed, removing virtual environment")
                 destroy_venv(env_path)
                 raise FadesError('Dependency installation failed')
 
@@ -180,7 +180,7 @@ def create_venv(requested_deps, interpreter, is_current, options, pip_options, a
 def destroy_venv(env_path, venvscache=None):
     """Destroy a venv."""
     # remove the venv itself in disk
-    logger.debug("Destroying virtualenv at: %s", env_path)
+    logger.debug("Destroying virtual environment at: %s", env_path)
     shutil.rmtree(env_path, ignore_errors=True)
 
     # remove venv from cache
@@ -245,7 +245,7 @@ class UsageManager:
                         # usage_file wasn't updated.
                         continue
                     env_path = venv_meta['env_path']
-                    logger.info("Destroying virtualenv at: %s", env_path)  # #256
+                    logger.info("Destroying virtual environment at: %s", env_path)
                     destroy_venv(env_path, self.venvscache)
 
             self._write_compacted_dict_usage_to_file(venvs_dict)

--- a/man/fades.1
+++ b/man/fades.1
@@ -34,11 +34,11 @@ fades - A system that automatically handles the virtualenvs in the cases normall
 
 .SH DESCRIPTION
 
-\fBfades\fR will automagically create a new virtualenv (or reuse a previous created one), installing the necessary dependencies, and execute your script inside that virtualenv, with the only requirement of executing the script with \fBfades\fR and also marking the required dependencies.
+\fBfades\fR will automagically create a new virtual environment (or reuse a previous created one), installing the necessary dependencies, and execute your script inside that virtual environment, with the only requirement of executing the script with \fBfades\fR and also marking the required dependencies.
 
 The first non-option parameter (if any) would be then the child program to execute, and any other parameters after that are passed as is to that child script.
 
-\fBfades\fR can also be executed without passing a child script to execute: in this mode it will open a Python interactive interpreter inside the created/reused virtualenv (taking dependencies from \fI--dependency\fR or \fI--requirement\fR options). If \fI--autoimport\fR is given, it will automatically import all the installed dependencies.
+\fBfades\fR can also be executed without passing a child script to execute: in this mode it will open a Python interactive interpreter inside the created/reused virtual environment (taking dependencies from \fI--dependency\fR or \fI--requirement\fR options). If \fI--autoimport\fR is given, it will automatically import all the installed dependencies.
 
 If the \fIchild_program\fR parameter is really an URL, the script will be automatically downloaded from there (supporting also the most common pastebins URLs: pastebin.com, linkode.org, gist, etc.).
 
@@ -88,11 +88,11 @@ The dependencies can be indicated in multiple places (in the Python source file,
 
 .TP
 .BR -x ", " --exec
-Execute the \fIchild_program\fR in the context of the virtualenv. The child_program, which in this case becomes a mandatory parameter, can be just the executable name (relative to the venv's bin directory) or an absolute path.
+Execute the \fIchild_program\fR in the context of the virtual environment. The child_program, which in this case becomes a mandatory parameter, can be just the executable name (relative to the venv's bin directory) or an absolute path.
 
 .TP
 .BR --rm " " \fIUUID\fR
-Remove a virtualenv by UUID.  See \fB--get-venv-dir\fR option to easily find out the UUID.
+Remove a virtual environment by UUID.  See \fB--get-venv-dir\fR option to easily find out the UUID.
 
 .TP
 .BR --system-site-packages ""
@@ -120,7 +120,7 @@ Will remove all virtualenvs that haven't been used for more than MAX_DAYS_TO_KEE
 
 .TP
 .BR --where ", " --get-venv-dir
-Show the virtualenv base directory (which includes the virtualenv UUID) and quit.
+Show the virtual environment base directory (which includes the virtual environment UUID) and quit.
 
 .TP
 .BR --no-precheck-availability
@@ -140,7 +140,7 @@ Run library module as a script (same behaviour than Python's \fB-m\fR parameter)
 
 .TP
 .BR --avoid-pip-upgrade
-Disable the automatic \fBpip\fR upgrade that happens after the virtualenv is created and before the dependencies begin to be installed.
+Disable the automatic \fBpip\fR upgrade that happens after the virtual environment is created and before the dependencies begin to be installed.
 
 
 .SH EXAMPLES
@@ -148,7 +148,7 @@ Disable the automatic \fBpip\fR upgrade that happens after the virtualenv is cre
 .TP
 fades foo.py --bar
 
-Executes foo.py under fades, passing the --bar parameter to the child program, in a virtualenv with the dependencies indicated in the source code.
+Executes foo.py under fades, passing the --bar parameter to the child program, in a virtual environment with the dependencies indicated in the source code.
 
 .TP
 fades -v foo.py
@@ -158,22 +158,22 @@ Executes foo.py under fades, showing all the fades messages (verbose mode).
 .TP
 fades -d dependency1 -d dependency2>3.2 foo.py --bar
 
-Executes foo.py under fades (passing the --bar parameter to it), in a virtualenv with the dependencies indicated in the source code and also dependency1 and dependency2 (any version > 3.2).
+Executes foo.py under fades (passing the --bar parameter to it), in a virtual environment with the dependencies indicated in the source code and also dependency1 and dependency2 (any version > 3.2).
 
 .TP
 fades -d dependency1
 
-Executes the Python interactive interpreter in a virtualenv with dependency1 installed.
+Executes the Python interactive interpreter in a virtual environment with dependency1 installed.
 
 .TP
 fades -r requirements.txt
 
-Executes the Python interactive interpreter in a virtualenv after installing there all dependencies taken from the requirements.txt file.
+Executes the Python interactive interpreter in a virtual environment after installing there all dependencies taken from the requirements.txt file.
 
 .TP
 fades -r requirements.txt -r requirements_devel.txt
 
-Executes the Python interactive interpreter in a virtualenv after installing there all dependencies taken from files requirements.txt and requirements_devel.txt.
+Executes the Python interactive interpreter in a virtual environment after installing there all dependencies taken from files requirements.txt and requirements_devel.txt.
 
 .SH USING CONFIGURATION FILES
 

--- a/tests/test_envbuilder.py
+++ b/tests/test_envbuilder.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Facundo Batista, Nicolás Demarchi
+# Copyright 2015-2024 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -161,7 +161,7 @@ class EnvCreationTestCase(unittest.TestCase):
                     self.assertEqual(str(cm.exception), 'Dependency installation failed')
                     mock_destroy.assert_called_once_with('env_path')
 
-        self.assertLoggedDebug("Installation Step failed, removing virtualenv")
+        self.assertLoggedDebug("Installation Step failed, removing virtual environment")
 
     def test_different_versions(self):
         requested = {


### PR DESCRIPTION
Previously we used 'virtualenv' to mean 'virtual environment', but it confuses everything because of the equally named `virtualenv` tool.