### PR TITLE
Stopped using pkg_resources, as it's deprecated.

### DIFF
--- a/.github/workflows/integtests.yaml
+++ b/.github/workflows/integtests.yaml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          pacman -Suy --noconfirm python3 python-setuptools
+          pacman -Suy --noconfirm python3 python-packaging
       - name: Simple fades run
         run: |
           cd /fades
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          yum install --assumeyes python3.12 python3-setuptools
+          yum install --assumeyes python3.12 python-packaging
       - name: Simple fades run
         run: |
           cd /fades
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ${{ steps.matrixpy.outputs.python-path }} -m pip install -U setuptools
+          ${{ steps.matrixpy.outputs.python-path }} -m pip install -U packaging
       - name: Simple fades run
         run: |
           ${{ steps.matrixpy.outputs.python-path }} bin/fades -v -d pytest -x pytest --version

--- a/README.rst
+++ b/README.rst
@@ -596,20 +596,7 @@ Else, keep reading to know how to install the dependencies first, and
 Dependencies
 ------------
 
-Besides needing Python 3.3 or greater, fades depends also on the
-``pkg_resources`` package, that comes in with ``setuptools``.
-It's installed almost everywhere, but in any case,
-you can install it in Ubuntu/Debian with::
-
-    apt-get install python3-setuptools
-
-And on Arch Linux with::
-
-    pacman -S python-setuptools
-
-It also depends on ``python-xdg`` package. This package should be
-installed on any GNU/Linux OS wiht a freedesktop.org GUI. However it
-is an **optional** dependency.
+Besides needing Python 3.3 or greater, fades depends on the ``python-xdg`` package. This package should be installed on any GNU/Linux OS wiht a freedesktop.org GUI. However it is an **optional** dependency.
 
 You can install it in Ubuntu/Debian with::
 

--- a/fades/envbuilder.py
+++ b/fades/envbuilder.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 Facundo Batista, Nicolás Demarchi
+# Copyright 2014-2024 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -169,7 +169,7 @@ def create_venv(requested_deps, interpreter, is_current, options, pip_options, a
                 # always store the installed dependency, as in the future we'll select the venv
                 # based on what is installed, not what used requested (remember that user may
                 # request >, >=, etc!)
-                project = dependency.project_name
+                project = dependency.name
                 version = mgr.get_version(project)
             installed[repo][project] = version
 

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Build-Depends: debhelper (>= 9),
                dh-python,
                dh-translations | dh-python,
-               python3-setuptools,
+               python3-packaging,
                python3-all (>= 3.4),
                python3-xdg
 Maintainer: Facundo Batista <facundo@taniquetil.com.ar>

--- a/pkg/snap/snapcraft.yaml
+++ b/pkg/snap/snapcraft.yaml
@@ -40,9 +40,8 @@ parts:
       - python3.8-minimal
       - python3-distutils
       - python3-minimal
-      - python3-pkg-resources
       - python3-pip
-      - python3-setuptools
+      - python3-packaging
       - python3-venv
       - python3-wheel
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flake8
 logassert
+packaging
 pydocstyle
 pytest
 pyuca

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2014-2017 Facundo Batista, Nicolás Demarchi
+# Copyright 2014-2024 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -22,8 +22,6 @@ Needed packages to run (using Debian/Ubuntu package names):
 
     python3
     python3-xdg   (optional)
-    python3-pkg-resources
-    python3-setuptools
 """
 
 import os
@@ -53,7 +51,7 @@ if sys.version_info.major < 3:
 def get_version():
     """Retrieves package version from the file."""
     with open('fades/_version.py') as fh:
-        m = re.search("\(([^']*)\)", fh.read())
+        m = re.search(r"\(([^']*)\)", fh.read())
     if m is None:
         raise ValueError("Unrecognized version in 'fades/_version.py'")
     return m.groups()[0].replace(', ', '.')
@@ -127,7 +125,7 @@ setup(
     extras_require={
         'pyxdg': 'pyxdg',
         'virtualenv': 'virtualenv',
-        'setuptools': 'setuptools',
+        'packaging': 'packaging',
     },
 
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 Facundo Batista, Nicolás Demarchi
+# Copyright 2017-2024 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -19,7 +19,7 @@
 import os
 from tempfile import mkstemp
 
-from pkg_resources import parse_requirements
+from packaging.requirements import Requirement
 
 
 def get_tempfile(testcase):
@@ -59,5 +59,5 @@ def get_python_filepaths(roots):
 
 
 def get_reqs(*items):
-    """Transform text requirements into pkg_resources objects."""
-    return list(parse_requirements(items))
+    """Transform text requirements into Requirement objects."""
+    return [Requirement(item) for item in items]

--- a/tests/test_cache/__init__.py
+++ b/tests/test_cache/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 Facundo Batista, Nicolás Demarchi
+# Copyright 2015-2024 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -16,9 +16,9 @@
 
 """Helpers for the Cache tests collection."""
 
-from pkg_resources import Distribution
+from fades.parsing import NameVerDependency
 
 
 def get_distrib(*dep_ver_pairs):
     """Build some Distributions with indicated info."""
-    return [Distribution(project_name=dep, version=ver) for dep, ver in dep_ver_pairs]
+    return [NameVerDependency(dep, ver) for dep, ver in dep_ver_pairs]

--- a/tests/test_envbuilder.py
+++ b/tests/test_envbuilder.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Facundo Batista, Nicolás Demarchi
+# Copyright 2015-2024 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -23,7 +23,7 @@ import unittest
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch, call
 
-from pkg_resources import parse_requirements
+from packaging.requirements import Requirement
 
 import logassert
 
@@ -33,8 +33,8 @@ from venv import EnvBuilder
 
 
 def get_req(text):
-    """Transform a text requirement into the pkg_resources object."""
-    return list(parse_requirements(text))[0]
+    """Transform a text requirement into the Requirement object."""
+    return Requirement(text)
 
 
 class EnvCreationTestCase(unittest.TestCase):

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Facundo Batista, Nicolás Demarchi
+# Copyright 2017-2024 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -49,7 +49,12 @@ def test_flake8_pytest(capsys):
 
 def test_pep257_pytest():
     python_filepaths = get_python_filepaths(PEP257_ROOTS)
-    result = list(pydocstyle.check(python_filepaths))
+    to_ignore = {
+        "D105",  # Missing docstring in magic method
+        "D107",  # Missing docstring in __init__
+    }
+    to_include = pydocstyle.violations.conventions.pep257 - to_ignore
+    result = list(pydocstyle.check(python_filepaths, select=to_include))
     assert len(result) == 0, "There are issues!\n" + '\n'.join(map(str, result))
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 Facundo Batista, Nicolás Demarchi
+# Copyright 2015-2024 Facundo Batista, Nicolás Demarchi
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -20,7 +20,7 @@ import os
 import unittest
 from unittest.mock import patch
 
-from pkg_resources import Requirement
+from packaging.requirements import Requirement
 
 from fades import VERSION, FadesError, __version__, main, parsing, REPO_PYPI, REPO_VCS
 from tests import create_tempfile
@@ -53,7 +53,7 @@ class DepsGatheringTestCase(unittest.TestCase):
         d = main.consolidate_dependencies(needs_ipython=True, child_program=None,
                                           requirement_files=None, manual_dependencies=None)
 
-        self.assertDictEqual(d, {'pypi': {Requirement.parse('ipython')}})
+        self.assertDictEqual(d, {'pypi': {Requirement('ipython')}})
 
     def test_child_program(self):
         child_program = 'tests/test_files/req_module.py'
@@ -61,7 +61,7 @@ class DepsGatheringTestCase(unittest.TestCase):
         d = main.consolidate_dependencies(needs_ipython=False, child_program=child_program,
                                           requirement_files=None, manual_dependencies=None)
 
-        self.assertDictEqual(d, {'pypi': {Requirement.parse('foo'), Requirement.parse('bar')}})
+        self.assertDictEqual(d, {'pypi': {Requirement('foo'), Requirement('bar')}})
 
     def test_requirement_files(self):
         requirement_files = [create_tempfile(self, ['dep'])]
@@ -70,7 +70,7 @@ class DepsGatheringTestCase(unittest.TestCase):
                                           requirement_files=requirement_files,
                                           manual_dependencies=None)
 
-        self.assertDictEqual(d, {'pypi': {Requirement.parse('dep')}})
+        self.assertDictEqual(d, {'pypi': {Requirement('dep')}})
 
     def test_manual_dependencies(self):
         manual_dependencies = ['dep']
@@ -79,7 +79,7 @@ class DepsGatheringTestCase(unittest.TestCase):
                                           requirement_files=None,
                                           manual_dependencies=manual_dependencies)
 
-        self.assertDictEqual(d, {'pypi': {Requirement.parse('dep')}})
+        self.assertDictEqual(d, {'pypi': {Requirement('dep')}})
 
 
 class DepsMergingTestCase(unittest.TestCase):
@@ -94,7 +94,7 @@ class DepsMergingTestCase(unittest.TestCase):
                                           manual_dependencies=manual_dependencies)
 
         self.assertEqual(d, {
-            'pypi': {Requirement.parse('1'), Requirement.parse('2')},
+            'pypi': {Requirement('1'), Requirement('2')},
             'vcs': {parsing.VCSDependency('3'), parsing.VCSDependency('4')}
         })
 
@@ -107,8 +107,7 @@ class DepsMergingTestCase(unittest.TestCase):
                                           manual_dependencies=manual_dependencies)
 
         self.assertDictEqual(d, {
-            'pypi': {Requirement.parse('1'), Requirement.parse('2'), Requirement.parse('3'),
-                     Requirement.parse('4')}
+            'pypi': {Requirement('1'), Requirement('2'), Requirement('3'), Requirement('4')}
         })
 
     def test_complex_case(self):
@@ -121,7 +120,7 @@ class DepsMergingTestCase(unittest.TestCase):
                                           manual_dependencies=manual_dependencies)
 
         self.assertEqual(d, {
-            'pypi': {Requirement.parse('1'), Requirement.parse('2'), Requirement.parse('3')},
+            'pypi': {Requirement('1'), Requirement('2'), Requirement('3')},
             'vcs': {parsing.VCSDependency('5'), parsing.VCSDependency('4'),
                     parsing.VCSDependency('6')}
         })
@@ -135,7 +134,7 @@ class DepsMergingTestCase(unittest.TestCase):
                                           manual_dependencies=manual_dependencies)
 
         self.assertDictEqual(d, {
-            'pypi': {Requirement.parse('2')}
+            'pypi': {Requirement('2')}
         })
 
     def test_two_different_with_dups(self):
@@ -147,7 +146,7 @@ class DepsMergingTestCase(unittest.TestCase):
                                           manual_dependencies=manual_dependencies)
 
         self.assertEqual(d, {
-            'pypi': {Requirement.parse('1'), Requirement.parse('2')},
+            'pypi': {Requirement('1'), Requirement('2')},
             'vcs': {parsing.VCSDependency('1'), parsing.VCSDependency('2'),
                     parsing.VCSDependency('3'), parsing.VCSDependency('4')}
         })
@@ -250,7 +249,7 @@ def _autoimport_safe_call(*args, **kwargs):
 def test_autoimport_simple():
     """Simplest autoimport call."""
     dependencies = {
-        REPO_PYPI: {Requirement.parse('mymod')},
+        REPO_PYPI: {Requirement('mymod')},
     }
     content = _autoimport_safe_call(dependencies, is_ipython=False)
 
@@ -261,7 +260,7 @@ def test_autoimport_simple():
 def test_autoimport_several_dependencies():
     """Indicate several dependencies."""
     dependencies = {
-        REPO_PYPI: {Requirement.parse('mymod1'), Requirement.parse('mymod2')},
+        REPO_PYPI: {Requirement('mymod1'), Requirement('mymod2')},
     }
     content = _autoimport_safe_call(dependencies, is_ipython=False)
 
@@ -274,8 +273,8 @@ def test_autoimport_including_ipython():
     """Call with ipython modifier."""
     dependencies = {
         REPO_PYPI: {
-            Requirement.parse('mymod'),
-            Requirement.parse('ipython'),  # this one is automatically added
+            Requirement('mymod'),
+            Requirement('ipython'),  # this one is automatically added
         },
     }
     content = _autoimport_safe_call(dependencies, is_ipython=True)
@@ -288,7 +287,7 @@ def test_autoimport_including_ipython():
 def test_autoimport_no_pypi_dep():
     """Case with no pypi dependencies."""
     dependencies = {
-        REPO_PYPI: {Requirement.parse('my_pypi_mod')},
+        REPO_PYPI: {Requirement('my_pypi_mod')},
         REPO_VCS: {'my_vcs_dependency'},
     }
     content = _autoimport_safe_call(dependencies, is_ipython=False)

--- a/tests/test_parsing/test_vcs_dependency.py
+++ b/tests/test_parsing/test_vcs_dependency.py
@@ -11,10 +11,8 @@ def test_string_representation():
 def test_contains():
     """This is particularly tested because it's how fulfilling is tested."""
     dep1 = parsing.VCSDependency("testurl")
-    dep2 = parsing.VCSDependency("testurl")
-    dep3 = parsing.VCSDependency("otherurl")
-    assert dep1 in dep2
-    assert dep1 not in dep3
+    assert dep1.specifier.contains(None)
+    assert not dep1.specifier.contains("123")
 
 
 def test_equality():


### PR DESCRIPTION
The replacement is the `packaging` module, but it's not exactly the same. It provides a `Requirement` object but it's different from the previous one, and there's no `Dependency` so to match versions we need to play with `Requirement.specifiers`.

The `VCSDependency` object we had grew in complexity, as it needs a new `VCSSpecifier` to mimic the new `Requirement`. Similarly, I added a `NameVerDependency` to be able to compare objects with name and version.

While working on this I found that in `check_pypi_updates` we were comparing versions as strings ("2.3" is greater than "1.3", but it is smaller than "10.2"... and if you compare the strings that is broken). I added a test for this and fixed it by using `packaging.Version` which compare as they should.

Finally, I removed all traces of "setuptools" and "pkg_resources" as a dependency needed to run.
