### PR TITLE
Show an error if the `packaging` dependency is not present

### DIFF
--- a/bin/fades
+++ b/bin/fades
@@ -22,6 +22,12 @@
 import os
 import sys
 
+try:
+    import packaging
+except ImportError:
+    print("Import failed for `packaging` dependency. Please do `pip3 install packaging` and try again")
+    exit(-1)
+
 # small hack to allow fades to be run directly from the project, using code
 # from project itself, not anything already installed in the system
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(sys.argv[0])))


### PR DESCRIPTION
MacOS lacks the `packaging` package by default. So running `bin/fades -V` fails with a stack trace.

This change is to show a more readable error when the required package is missing.