### PR TITLE
integtests: drop custom Arch image; provision older Python from setup.py

### DIFF
--- a/.github/workflows/integtests.yaml
+++ b/.github/workflows/integtests.yaml
@@ -11,8 +11,10 @@ jobs:
   archlinux:
     runs-on: ubuntu-latest
     container:
-      # Use https://github.com/gilgamezh/archlinux-python39 to save the python build time
-      image: gilgamezh/archlinux-python39:latest
+      # archlinux:latest ships the newest CPython (rolling release), so this
+      # job exercises fades against the bleeding-edge Python. An older
+      # interpreter for the cross-version test is provided via uv at runtime.
+      image: archlinux:latest
       volumes:
         - ${{ github.workspace }}:/fades
     steps:
@@ -22,14 +24,17 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          pacman -Suy --noconfirm python3 python-packaging
-      - name: Simple fades run
+          pacman -Suy --noconfirm python3 python-packaging uv git
+      - name: Simple fades run (newest Python)
         run: |
           cd /fades
           bin/fades -v -d pytest -x pytest --version
-      - name: Using a different Python
+      - name: Using a different (older) Python
         run: |
-          python bin/fades -v --python=python3.9 -d pytest -x pytest -v --integtest-pyversion=3.9 tests/integtest.py
+          cd /fades
+          uv python install 3.11
+          OLD=$(uv python find 3.11)
+          python bin/fades -v --python="$OLD" -d pytest -x pytest -v --integtest-pyversion=3.11 tests/integtest.py
 
   fedora:
     runs-on: ubuntu-latest

--- a/.github/workflows/integtests.yaml
+++ b/.github/workflows/integtests.yaml
@@ -74,20 +74,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        uses: actions/setup-python@v5
+        id: matrixpy
+        with:
+          python-version: ${{ matrix.python-version }}
 
-      - name: Set up Pythons
-        run: uv python install ${{ matrix.python-version }} 3.10
+      - name: Also set up Python 3.10 for cross-Python test
+        uses: actions/setup-python@v5
+        id: otherpy
+        with:
+          python-version: "3.10"
 
+      - name: Install dependencies
+        run: |
+          ${{ steps.matrixpy.outputs.python-path }} -m pip install -U packaging
       - name: Simple fades run
-        run: uv run --no-project --python ${{ matrix.python-version }} --with packaging -- python bin/fades -v -d pytest -x pytest --version
+        run: |
+          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v -d pytest -x pytest --version
 
       - name: Using a different Python
-        shell: bash
         run: |
-          OTHER=$(uv python find 3.10)
-          uv run --no-project --python ${{ matrix.python-version }} --with packaging -- python bin/fades -v --python="$OTHER" -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py
+          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v --python=${{ steps.otherpy.outputs.python-path }} -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py
 
   native-generic:
     strategy:
@@ -102,17 +110,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        uses: actions/setup-python@v5
+        id: matrixpy
+        with:
+          python-version: ${{ matrix.python-version }}
 
-      - name: Set up Pythons
-        run: uv python install ${{ matrix.python-version }} 3.10
+      - name: Also set up Python 3.10 for cross-Python test
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
 
+      - name: Install dependencies
+        run: |
+          ${{ steps.matrixpy.outputs.python-path }} -m pip install -U packaging
       - name: Simple fades run
-        run: uv run --no-project --python ${{ matrix.python-version }} --with packaging -- python bin/fades -v -d pytest -x pytest --version
+        run: |
+          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v -d pytest -x pytest --version
 
       - name: Using a different Python
-        shell: bash
         run: |
-          OTHER=$(uv python find 3.10)
-          uv run --no-project --python ${{ matrix.python-version }} --with packaging -- python bin/fades -v --python="$OTHER" -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py
+          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v --python=python3.10 -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py

--- a/.github/workflows/integtests.yaml
+++ b/.github/workflows/integtests.yaml
@@ -8,7 +8,24 @@ on:
 
 jobs:
 
+  # Single source of truth: the oldest supported Python is whatever setup.py
+  # declares in `python_requires`. Every job below derives its cross-version
+  # target from this output instead of hardcoding a version.
+  min-python:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.minpy.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read minimum supported Python from setup.py
+        id: minpy
+        run: |
+          version=$(grep python_requires setup.py | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          echo "Minimum supported Python: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
   archlinux:
+    needs: min-python
     runs-on: ubuntu-latest
     container:
       # archlinux:latest ships the newest CPython (rolling release), so this
@@ -29,14 +46,17 @@ jobs:
         run: |
           cd /fades
           bin/fades -v -d pytest -x pytest --version
-      - name: Using a different (older) Python
+      - name: Using the oldest supported Python
+        env:
+          OLDEST: ${{ needs.min-python.outputs.version }}
         run: |
           cd /fades
-          uv python install 3.11
-          OLD=$(uv python find 3.11)
-          python bin/fades -v --python="$OLD" -d pytest -x pytest -v --integtest-pyversion=3.11 tests/integtest.py
+          uv python install "$OLDEST"
+          OLD=$(uv python find "$OLDEST")
+          python bin/fades -v --python="$OLD" -d pytest -x pytest -v --integtest-pyversion="$OLDEST" tests/integtest.py
 
   fedora:
+    needs: min-python
     runs-on: ubuntu-latest
     container:
       image: fedora:latest
@@ -54,21 +74,24 @@ jobs:
         run: |
           cd /fades
           bin/fades -v -d pytest -x pytest --version
-      - name: Using a different (older) Python
+      - name: Using the oldest supported Python
+        env:
+          OLDEST: ${{ needs.min-python.outputs.version }}
         run: |
           cd /fades
-          uv python install 3.11
-          OLD=$(uv python find 3.11)
-          python3 bin/fades -v --python="$OLD" -d pytest -x pytest -v --integtest-pyversion=3.11 tests/integtest.py
+          uv python install "$OLDEST"
+          OLD=$(uv python find "$OLDEST")
+          python3 bin/fades -v --python="$OLD" -d pytest -x pytest -v --integtest-pyversion="$OLDEST" tests/integtest.py
 
   native-windows:
+    needs: min-python
     strategy:
       matrix:
         # just a selection otherwise it's too much
         # - latest OS (left here even if it's only one to simplify upgrading later)
-        # - oldest and newest Python
+        # - oldest (from setup.py) and newest Python
         os: [windows-2025]
-        python-version: [3.8, "3.13"]
+        python-version: ["${{ needs.min-python.outputs.version }}", "3.13"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -80,11 +103,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Also set up Python 3.10 for cross-Python test
+      - name: Also set up the oldest supported Python for cross-Python test
         uses: actions/setup-python@v5
         id: otherpy
         with:
-          python-version: "3.10"
+          python-version: ${{ needs.min-python.outputs.version }}
 
       - name: Install dependencies
         run: |
@@ -95,16 +118,17 @@ jobs:
 
       - name: Using a different Python
         run: |
-          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v --python=${{ steps.otherpy.outputs.python-path }} -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py
+          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v --python=${{ steps.otherpy.outputs.python-path }} -d pytest -x pytest -v --integtest-pyversion=${{ needs.min-python.outputs.version }} tests/integtest.py
 
   native-generic:
+    needs: min-python
     strategy:
       matrix:
         # just a selection otherwise it's too much
         # - latest OSes
-        # - oldest and newest Python
+        # - oldest (from setup.py) and newest Python
         os: [ubuntu-24.04, macos-15]
-        python-version: [3.8, "3.13"]
+        python-version: ["${{ needs.min-python.outputs.version }}", "3.13"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -116,10 +140,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Also set up Python 3.10 for cross-Python test
+      - name: Also set up the oldest supported Python for cross-Python test
         uses: actions/setup-python@v5
+        id: otherpy
         with:
-          python-version: "3.10"
+          python-version: ${{ needs.min-python.outputs.version }}
 
       - name: Install dependencies
         run: |
@@ -130,4 +155,4 @@ jobs:
 
       - name: Using a different Python
         run: |
-          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v --python=python3.10 -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py
+          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v --python=${{ steps.otherpy.outputs.python-path }} -d pytest -x pytest -v --integtest-pyversion=${{ needs.min-python.outputs.version }} tests/integtest.py

--- a/.github/workflows/integtests.yaml
+++ b/.github/workflows/integtests.yaml
@@ -49,16 +49,17 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          yum install --assumeyes python3.13 python-packaging
+          dnf install --assumeyes python3 python3-packaging uv git
       - name: Simple fades run
         run: |
           cd /fades
           bin/fades -v -d pytest -x pytest --version
-      - name: Using a different Python
+      - name: Using a different (older) Python
         run: |
-          yum install --assumeyes python3.9
           cd /fades
-          python3.13 bin/fades -v --python=python3.9 -d pytest -x pytest -v --integtest-pyversion=3.9 tests/integtest.py
+          uv python install 3.11
+          OLD=$(uv python find 3.11)
+          python3 bin/fades -v --python="$OLD" -d pytest -x pytest -v --integtest-pyversion=3.11 tests/integtest.py
 
   native-windows:
     strategy:
@@ -73,28 +74,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v5
-        id: matrixpy
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
-      - name: Also set up Python 3.10 for cross-Python test
-        uses: actions/setup-python@v5
-        id: otherpy
-        with:
-          python-version: "3.10"
+      - name: Set up Pythons
+        run: uv python install ${{ matrix.python-version }} 3.10
 
-      - name: Install dependencies
-        run: |
-          ${{ steps.matrixpy.outputs.python-path }} -m pip install -U packaging
       - name: Simple fades run
-        run: |
-          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v -d pytest -x pytest --version
+        run: uv run --no-project --python ${{ matrix.python-version }} --with packaging -- python bin/fades -v -d pytest -x pytest --version
 
       - name: Using a different Python
+        shell: bash
         run: |
-          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v --python=${{ steps.otherpy.outputs.python-path }} -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py
+          OTHER=$(uv python find 3.10)
+          uv run --no-project --python ${{ matrix.python-version }} --with packaging -- python bin/fades -v --python="$OTHER" -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py
 
   native-generic:
     strategy:
@@ -109,24 +102,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v5
-        id: matrixpy
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
-      - name: Also set up Python 3.10 for cross-Python test
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Pythons
+        run: uv python install ${{ matrix.python-version }} 3.10
 
-      - name: Install dependencies
-        run: |
-          ${{ steps.matrixpy.outputs.python-path }} -m pip install -U packaging
       - name: Simple fades run
-        run: |
-          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v -d pytest -x pytest --version
+        run: uv run --no-project --python ${{ matrix.python-version }} --with packaging -- python bin/fades -v -d pytest -x pytest --version
 
       - name: Using a different Python
+        shell: bash
         run: |
-          ${{ steps.matrixpy.outputs.python-path }} bin/fades -v --python=python3.10 -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py
+          OTHER=$(uv python find 3.10)
+          uv run --no-project --python ${{ matrix.python-version }} --with packaging -- python bin/fades -v --python="$OTHER" -d pytest -x pytest -v --integtest-pyversion=3.10 tests/integtest.py


### PR DESCRIPTION
> **Stacked on #450** (base branch `deprecate-python39`). Merge #450 first; this PR's diff is only `integtests.yaml`.

## What

Modernizes interpreter provisioning in the integration tests and removes the custom `gilgamezh/archlinux-python39` Docker image.

## Approach (revised)

- **archlinux**: `gilgamezh/archlinux-python39:latest` → `archlinux:latest` (already ships the newest CPython). The older interpreter for the cross-version test comes from `uv python install`. fades runs under the system Python and uv only supplies the **target** interpreter path via `uv python find` — fades is **not** wrapped in a venv.
- **fedora**: install `uv` from the distro instead of `yum install python3.9` (which no longer resolves); older target via uv.
- **native-windows / native-generic**: kept on `actions/setup-python`. An earlier attempt used `uv run`, but that executes fades **inside an ephemeral venv**, and fades refuses to run inside a virtualenv (it is a venv manager itself). setup-python provides each interpreter cleanly on every OS with no venv wrapper, so those jobs stay as they were.

## Single source of truth

A new `min-python` job parses the minimum supported version from `setup.py`'s `python_requires` and exposes it as an output. Every job derives its cross-version target from that output instead of hardcoding — so bumping the floor in `setup.py` automatically updates the integration tests. (The `>=3.10` floor itself comes from #450.)

## Notes

- Verified locally: fades run under Python 3.14 builds a venv with a uv-provided 3.11 interpreter, installs and runs pytest successfully.
- Watch the first CI run to confirm the `needs.min-python` output flows into the matrix and steps on every OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)